### PR TITLE
refactor(stream): added integer size and signed type to function names

### DIFF
--- a/khepri/include/khepri/io/stream.hpp
+++ b/khepri/include/khepri/io/stream.hpp
@@ -64,31 +64,37 @@ public:
     /// Reads a boolean (one byte) from the stream
     bool read_bool()
     {
-        return read_byte() != 0;
+        return read_uint8() != 0;
     }
 
     /// Reads a 16-bit signed little-endian integer from the stream
-    int read_short();
+    int16_t read_int16();
 
     /// Reads a 32-bit signed little-endian integer from the stream
-    long read_int();
+    int32_t read_int32();
+
+    /// Reads a 64-bit signed little-endian integer from the stream
+    int64_t read_int64();
 
     /// Reads a 32-bit little-endian IEEE 754 floating-point number from the stream
     float read_float();
 
     /// Reads an unsigned byte from the stream
-    unsigned char read_byte();
+    uint8_t read_uint8();
 
     /// Reads a 16-bit unsigned little-endian integer from the stream
-    unsigned int read_ushort();
+    uint16_t read_uint16();
 
     /// Reads a 32-bit unsigned little-endian integer from the stream
-    unsigned long read_uint();
+    uint32_t read_uint32();
+
+    /// Reads a 64-bit unsigned little-endian integer from the stream
+    uint64_t read_uint64();
 
     /**
      * \brief Reads a string from the stream.
      *
-     * This first reads the length of the string as if via #read_ushort(), followed
+     * This first reads the length of the string as if via #read_uint16(), followed
      * by that many bytes as the contents of the string.
      */
     std::string read_string();
@@ -96,31 +102,40 @@ public:
     /// Writes a boolean (one byte) to the stream
     void write_bool(bool b)
     {
-        write_byte(b ? 1 : 0);
+        write_uint8(b ? 1 : 0);
     }
 
     /// Writes a 16-bit signed little-endian integer to the stream
-    void write_short(int s);
+    void write_int8(int8_t i8);
+
+    /// Writes a 16-bit signed little-endian integer to the stream
+    void write_int16(int16_t i16);
 
     /// Writes a 32-bit signed little-endian integer to the stream
-    void write_int(long i);
+    void write_int32(int32_t i32);
+
+    /// Writes a 64-bit signed little-endian integer to the stream
+    void write_int64(int64_t i64);
+
+    /// Writes a byte/uint8_t to the stream
+    void write_uint8(uint8_t u8);
+
+    /// Writes a 16-bit unsigned little-endian integer to the stream
+    void write_uint16(uint16_t u16);
+
+    /// Writes a 32-bit unsigned little-endian integer to the stream
+    void write_uint32(uint32_t u32);
+
+    /// Writes a 32-bit unsigned little-endian integer to the stream
+    void write_uint64(uint64_t u64);
 
     /// Writes a 32-bit little-endian IEEE-754 floating-point number to the stream
     void write_float(float f);
 
-    /// Writes a byte to the stream
-    void write_byte(unsigned char b);
-
-    /// Writes a 16-bit unsigned little-endian integer to the stream
-    void write_ushort(unsigned int s);
-
-    /// Writes a 32-bit unsigned little-endian integer to the stream
-    void write_uint(unsigned long i);
-
     /**
      * \brief Writes a string to the stream.
      *
-     * This first writes the length of the string as if via #write_ushort(), followed
+     * This first writes the length of the string as if via #write_uint16(), followed
      * by that many bytes as the contents of the string.
      *
      * \note The length of \a s must not exceed 65535.

--- a/khepri/include/khepri/io/stream.hpp
+++ b/khepri/include/khepri/io/stream.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace khepri::io {

--- a/khepri/include/khepri/io/stream.hpp
+++ b/khepri/include/khepri/io/stream.hpp
@@ -68,28 +68,28 @@ public:
     }
 
     /// Reads a 16-bit signed little-endian integer from the stream
-    int16_t read_int16();
+    std::int16_t read_int16();
 
     /// Reads a 32-bit signed little-endian integer from the stream
-    int32_t read_int32();
+    std::int32_t read_int32();
 
     /// Reads a 64-bit signed little-endian integer from the stream
-    int64_t read_int64();
+    std::int64_t read_int64();
 
     /// Reads a 32-bit little-endian IEEE 754 floating-point number from the stream
     float read_float();
 
     /// Reads an unsigned byte from the stream
-    uint8_t read_uint8();
+    std::uint8_t read_uint8();
 
     /// Reads a 16-bit unsigned little-endian integer from the stream
-    uint16_t read_uint16();
+    std::uint16_t read_uint16();
 
     /// Reads a 32-bit unsigned little-endian integer from the stream
-    uint32_t read_uint32();
+    std::uint32_t read_uint32();
 
     /// Reads a 64-bit unsigned little-endian integer from the stream
-    uint64_t read_uint64();
+    std::uint64_t read_uint64();
 
     /**
      * \brief Reads a string from the stream.
@@ -106,28 +106,28 @@ public:
     }
 
     /// Writes a 16-bit signed little-endian integer to the stream
-    void write_int8(int8_t i8);
+    void write_int8(std::int8_t i8);
 
     /// Writes a 16-bit signed little-endian integer to the stream
-    void write_int16(int16_t i16);
+    void write_int16(std::int16_t i16);
 
     /// Writes a 32-bit signed little-endian integer to the stream
-    void write_int32(int32_t i32);
+    void write_int32(std::int32_t i32);
 
     /// Writes a 64-bit signed little-endian integer to the stream
-    void write_int64(int64_t i64);
+    void write_int64(std::int64_t i64);
 
     /// Writes a byte/uint8_t to the stream
-    void write_uint8(uint8_t u8);
+    void write_uint8(std::uint8_t u8);
 
     /// Writes a 16-bit unsigned little-endian integer to the stream
-    void write_uint16(uint16_t u16);
+    void write_uint16(std::uint16_t u16);
 
     /// Writes a 32-bit unsigned little-endian integer to the stream
-    void write_uint32(uint32_t u32);
+    void write_uint32(std::uint32_t u32);
 
     /// Writes a 32-bit unsigned little-endian integer to the stream
-    void write_uint64(uint64_t u64);
+    void write_uint64(std::uint64_t u64);
 
     /// Writes a 32-bit little-endian IEEE-754 floating-point number to the stream
     void write_float(float f);

--- a/khepri/src/io/container_stream.cpp
+++ b/khepri/src/io/container_stream.cpp
@@ -36,16 +36,16 @@ ContainerStream::ContainerStream(Stream& underlying_stream, ContentTypeId type_i
         underlying_stream.read(file_magic.data(), file_magic.size());
         require(file_magic == MAGIC);
 
-        const auto version = underlying_stream.read_byte();
+        const auto version = underlying_stream.read_uint8();
         require(version == FORMAT_VERSION);
 
-        const auto file_type_id = underlying_stream.read_uint();
+        const auto file_type_id = underlying_stream.read_uint32();
         require(type_id == file_type_id);
 
-        const auto flags = underlying_stream.read_uint();
+        const auto flags = underlying_stream.read_uint32();
         require(flags == 0);
 
-        m_content_size = underlying_stream.read_uint();
+        m_content_size = underlying_stream.read_uint32();
 
         if (underlying_stream.seekable()) {
             m_content_start = underlying_stream.seek(0, SeekOrigin::current);
@@ -59,10 +59,10 @@ ContainerStream::ContainerStream(Stream& underlying_stream, ContentTypeId type_i
 
         // Write the file header
         underlying_stream.write(MAGIC.data(), MAGIC.size());
-        underlying_stream.write_byte(FORMAT_VERSION);
-        underlying_stream.write_uint(type_id);
-        underlying_stream.write_uint(0); // flags
-        underlying_stream.write_uint(0); // size
+        underlying_stream.write_uint8(FORMAT_VERSION);
+        underlying_stream.write_uint32(type_id);
+        underlying_stream.write_uint32(0); // flags
+        underlying_stream.write_uint32(0); // size
 
         m_content_start = underlying_stream.seek(0, SeekOrigin::current);
     }
@@ -75,7 +75,7 @@ void ContainerStream::close()
             const auto size_offset =
                 m_content_start - static_cast<long long>(sizeof(std::uint32_t));
             m_underlying_stream->seek(size_offset, SeekOrigin::begin);
-            m_underlying_stream->write_uint(static_cast<std::uint32_t>(m_content_size));
+            m_underlying_stream->write_uint32(static_cast<std::uint32_t>(m_content_size));
         }
         m_underlying_stream = nullptr;
     }

--- a/khepri/src/io/stream.cpp
+++ b/khepri/src/io/stream.cpp
@@ -23,37 +23,23 @@ void write_checked(Stream& stream, const void* data, std::size_t count)
 }
 } // namespace
 
-int Stream::read_short()
+int16_t Stream::read_int16()
 {
     std::int16_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
 
-long Stream::read_int()
+int32_t Stream::read_int32()
 {
     std::int32_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
 
-unsigned char Stream::read_byte()
+int64_t Stream::read_int64()
 {
-    std::int8_t x{};
-    read_checked(*this, &x, sizeof x);
-    return x;
-}
-
-unsigned int Stream::read_ushort()
-{
-    std::int16_t x{};
-    read_checked(*this, &x, sizeof x);
-    return x;
-}
-
-unsigned long Stream::read_uint()
-{
-    std::int32_t x{};
+    std::int64_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
@@ -65,9 +51,37 @@ float Stream::read_float()
     return x;
 }
 
+uint8_t Stream::read_uint8()
+{
+    std::int8_t x{};
+    read_checked(*this, &x, sizeof x);
+    return x;
+}
+
+uint16_t Stream::read_uint16()
+{
+    std::int16_t x{};
+    read_checked(*this, &x, sizeof x);
+    return x;
+}
+
+uint32_t Stream::read_uint32()
+{
+    std::int32_t x{};
+    read_checked(*this, &x, sizeof x);
+    return x;
+}
+
+uint64_t Stream::read_uint64()
+{
+    std::int64_t x{};
+    read_checked(*this, &x, sizeof x);
+    return x;
+}
+
 std::string Stream::read_string()
 {
-    std::vector<char> x(read_ushort());
+    std::vector<char> x(read_uint16());
     if (!x.empty()) {
         read_checked(*this, x.data(), x.size());
         return {x.begin(), x.end()};
@@ -75,34 +89,44 @@ std::string Stream::read_string()
     return "";
 }
 
-void Stream::write_short(int s)
+void Stream::write_int8(int8_t i8)
 {
-    const auto x = static_cast<std::uint16_t>(static_cast<unsigned int>(s));
-    write_checked(*this, &x, sizeof x);
+    write_checked(*this, &i8, sizeof i8);
 }
 
-void Stream::write_int(long i)
+void Stream::write_int16(int16_t i16)
 {
-    const auto x = static_cast<std::uint32_t>(static_cast<unsigned long>(i));
-    write_checked(*this, &x, sizeof x);
+    write_checked(*this, &i16, sizeof i16);
 }
 
-void Stream::write_byte(unsigned char b)
+void Stream::write_int32(int32_t i32)
 {
-    const auto x = static_cast<std::uint8_t>(b);
-    write_checked(*this, &x, sizeof x);
+    write_checked(*this, &i32, sizeof i32);
 }
 
-void Stream::write_ushort(unsigned int s)
+void Stream::write_int64(int64_t i64)
 {
-    const auto x = static_cast<std::uint16_t>(s);
-    write_checked(*this, &x, sizeof x);
+    write_checked(*this, &i64, sizeof i64);
 }
 
-void Stream::write_uint(unsigned long i)
+void Stream::write_uint8(uint8_t u8)
 {
-    const auto x = static_cast<std::uint32_t>(i);
-    write_checked(*this, &x, sizeof x);
+    write_checked(*this, &u8, sizeof u8);
+}
+
+void Stream::write_uint16(uint16_t u16)
+{
+    write_checked(*this, &u16, sizeof u16);
+}
+
+void Stream::write_uint32(uint32_t u32)
+{
+    write_checked(*this, &u32, sizeof u32);
+}
+
+void Stream::write_uint64(uint64_t u64)
+{
+    write_checked(*this, &u64, sizeof u64);
 }
 
 void Stream::write_float(float f)
@@ -113,7 +137,7 @@ void Stream::write_float(float f)
 void Stream::write_string(const std::string& s)
 {
     assert(s.size() <= std::numeric_limits<uint16_t>::max());
-    write_ushort(static_cast<unsigned short>(s.size()));
+    write_uint16(static_cast<unsigned short>(s.size()));
     write_checked(*this, s.c_str(), s.size());
 }
 

--- a/khepri/src/io/stream.cpp
+++ b/khepri/src/io/stream.cpp
@@ -23,21 +23,21 @@ void write_checked(Stream& stream, const void* data, std::size_t count)
 }
 } // namespace
 
-int16_t Stream::read_int16()
+std::int16_t Stream::read_int16()
 {
     std::int16_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
 
-int32_t Stream::read_int32()
+std::int32_t Stream::read_int32()
 {
     std::int32_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
 
-int64_t Stream::read_int64()
+std::int64_t Stream::read_int64()
 {
     std::int64_t x{};
     read_checked(*this, &x, sizeof x);
@@ -51,28 +51,28 @@ float Stream::read_float()
     return x;
 }
 
-uint8_t Stream::read_uint8()
+std::uint8_t Stream::read_uint8()
 {
     std::int8_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
 
-uint16_t Stream::read_uint16()
+std::uint16_t Stream::read_uint16()
 {
     std::int16_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
 
-uint32_t Stream::read_uint32()
+std::uint32_t Stream::read_uint32()
 {
     std::int32_t x{};
     read_checked(*this, &x, sizeof x);
     return x;
 }
 
-uint64_t Stream::read_uint64()
+std::uint64_t Stream::read_uint64()
 {
     std::int64_t x{};
     read_checked(*this, &x, sizeof x);
@@ -89,42 +89,42 @@ std::string Stream::read_string()
     return "";
 }
 
-void Stream::write_int8(int8_t i8)
+void Stream::write_int8(std::int8_t i8)
 {
     write_checked(*this, &i8, sizeof i8);
 }
 
-void Stream::write_int16(int16_t i16)
+void Stream::write_int16(std::int16_t i16)
 {
     write_checked(*this, &i16, sizeof i16);
 }
 
-void Stream::write_int32(int32_t i32)
+void Stream::write_int32(std::int32_t i32)
 {
     write_checked(*this, &i32, sizeof i32);
 }
 
-void Stream::write_int64(int64_t i64)
+void Stream::write_int64(std::int64_t i64)
 {
     write_checked(*this, &i64, sizeof i64);
 }
 
-void Stream::write_uint8(uint8_t u8)
+void Stream::write_uint8(std::uint8_t u8)
 {
     write_checked(*this, &u8, sizeof u8);
 }
 
-void Stream::write_uint16(uint16_t u16)
+void Stream::write_uint16(std::uint16_t u16)
 {
     write_checked(*this, &u16, sizeof u16);
 }
 
-void Stream::write_uint32(uint32_t u32)
+void Stream::write_uint32(std::uint32_t u32)
 {
     write_checked(*this, &u32, sizeof u32);
 }
 
-void Stream::write_uint64(uint64_t u64)
+void Stream::write_uint64(std::uint64_t u64)
 {
     write_checked(*this, &u64, sizeof u64);
 }

--- a/khepri/src/io/stream.cpp
+++ b/khepri/src/io/stream.cpp
@@ -2,7 +2,6 @@
 #include <khepri/io/stream.hpp>
 
 #include <cassert>
-#include <cstdint>
 #include <vector>
 
 namespace khepri::io {

--- a/khepri/src/renderer/io/texture_dds.cpp
+++ b/khepri/src/renderer/io/texture_dds.cpp
@@ -279,7 +279,7 @@ bool is_texture_dds(khepri::io::Stream& stream)
 {
     assert(stream.readable() && stream.seekable());
     try {
-        const auto magic = stream.read_uint();
+        const auto magic = stream.read_uint32();
         return magic == DDS_MAGIC;
     } catch (const khepri::io::Error&) {
     }
@@ -315,29 +315,29 @@ TextureDesc load_texture_dds(khepri::io::Stream& stream)
     assert(stream.readable() && stream.seekable());
     TextureDimension dimension = TextureDimension::texture_2d;
 
-    auto magic = stream.read_uint();
+    auto magic = stream.read_uint32();
     verify(magic == DDS_MAGIC);
 
-    auto size   = stream.read_uint();
-    auto flags  = stream.read_uint();
-    auto height = stream.read_uint();
-    auto width  = stream.read_uint();
+    auto size   = stream.read_uint32();
+    auto flags  = stream.read_uint32();
+    auto height = stream.read_uint32();
+    auto width  = stream.read_uint32();
 
     // Ignore pitch/linear size, it's unreliable. We must calculate it ourselves.
-    stream.read_uint();
+    stream.read_uint32();
 
-    auto depth = stream.read_uint();
+    auto depth = stream.read_uint32();
     if ((flags & ddsf_depth) != 0) {
         // 3D (volume) texture
-        depth     = std::max(1UL, depth);
+        depth     = std::max((uint32_t)1, depth);
         dimension = TextureDimension::texture_3d;
     } else {
         depth = 1;
     }
 
-    auto mip_levels = stream.read_uint();
+    auto mip_levels = stream.read_uint32();
     if ((flags & ddsf_mipmapcount) != 0) {
-        mip_levels = std::max(1UL, mip_levels);
+        mip_levels = std::max((uint32_t)1, mip_levels);
     } else {
         mip_levels = 1;
     }
@@ -345,25 +345,25 @@ TextureDesc load_texture_dds(khepri::io::Stream& stream)
     // Reserved data
     constexpr auto num_reserved_uints = 11;
     for (int i = 0; i < num_reserved_uints; ++i) {
-        stream.read_uint();
+        stream.read_uint32();
     }
 
     // Pixel format
-    auto           pf_size = stream.read_uint();
+    auto           pf_size = stream.read_uint32();
     DdsPixelFormat ddpf{};
-    ddpf.flags        = stream.read_uint();
-    ddpf.fourcc       = stream.read_uint();
-    ddpf.rgb_bitcount = stream.read_uint();
-    ddpf.r_mask       = stream.read_uint();
-    ddpf.g_mask       = stream.read_uint();
-    ddpf.b_mask       = stream.read_uint();
-    ddpf.a_mask       = stream.read_uint();
+    ddpf.flags        = stream.read_uint32();
+    ddpf.fourcc       = stream.read_uint32();
+    ddpf.rgb_bitcount = stream.read_uint32();
+    ddpf.r_mask       = stream.read_uint32();
+    ddpf.g_mask       = stream.read_uint32();
+    ddpf.b_mask       = stream.read_uint32();
+    ddpf.a_mask       = stream.read_uint32();
 
-    stream.read_uint(); // Caps. Ignored, contains no relevant data.
-    auto caps2 = stream.read_uint();
-    stream.read_uint(); // Caps3. Unused
-    stream.read_uint(); // Caps4. Unused.
-    stream.read_uint(); // Reserved
+    stream.read_uint32(); // Caps. Ignored, contains no relevant data.
+    auto caps2 = stream.read_uint32();
+    stream.read_uint32(); // Caps3. Unused
+    stream.read_uint32(); // Caps4. Unused.
+    stream.read_uint32(); // Reserved
 
     verify(size == DDS_HEADER_SIZE);
     verify((flags & DDS_REQUIRED_FLAGS) == DDS_REQUIRED_FLAGS);

--- a/khepri/src/renderer/io/texture_tga.cpp
+++ b/khepri/src/renderer/io/texture_tga.cpp
@@ -48,35 +48,35 @@ void verify(bool condition)
 Header read_header(khepri::io::Stream& stream)
 {
     Header hdr{};
-    hdr.image_id_length  = stream.read_byte();
-    hdr.color_map_type   = stream.read_byte();
-    hdr.image_type       = stream.read_byte();
-    hdr.color_map_start  = stream.read_short();
-    hdr.color_map_length = stream.read_short();
-    hdr.color_map_bpp    = stream.read_byte();
-    hdr.image_x          = stream.read_short();
-    hdr.image_y          = stream.read_short();
-    hdr.image_width      = stream.read_short();
-    hdr.image_height     = stream.read_short();
-    hdr.image_bpp        = stream.read_byte();
-    hdr.image_descriptor = stream.read_byte();
+    hdr.image_id_length  = stream.read_uint8();
+    hdr.color_map_type   = stream.read_uint8();
+    hdr.image_type       = stream.read_uint8();
+    hdr.color_map_start  = stream.read_int16();
+    hdr.color_map_length = stream.read_int16();
+    hdr.color_map_bpp    = stream.read_uint8();
+    hdr.image_x          = stream.read_int16();
+    hdr.image_y          = stream.read_int16();
+    hdr.image_width      = stream.read_int16();
+    hdr.image_height     = stream.read_int16();
+    hdr.image_bpp        = stream.read_uint8();
+    hdr.image_descriptor = stream.read_uint8();
     return hdr;
 }
 
 void write_header(khepri::io::Stream& stream, const Header& hdr)
 {
-    stream.write_byte(hdr.image_id_length);
-    stream.write_byte(hdr.color_map_type);
-    stream.write_byte(hdr.image_type);
-    stream.write_short(hdr.color_map_start);
-    stream.write_short(hdr.color_map_length);
-    stream.write_byte(hdr.color_map_bpp);
-    stream.write_short(hdr.image_x);
-    stream.write_short(hdr.image_y);
-    stream.write_short(hdr.image_width);
-    stream.write_short(hdr.image_height);
-    stream.write_byte(hdr.image_bpp);
-    stream.write_byte(hdr.image_descriptor);
+    stream.write_uint8(hdr.image_id_length);
+    stream.write_uint8(hdr.color_map_type);
+    stream.write_uint8(hdr.image_type);
+    stream.write_int16(hdr.color_map_start);
+    stream.write_int16(hdr.color_map_length);
+    stream.write_uint8(hdr.color_map_bpp);
+    stream.write_int16(hdr.image_x);
+    stream.write_int16(hdr.image_y);
+    stream.write_int16(hdr.image_width);
+    stream.write_int16(hdr.image_height);
+    stream.write_uint8(hdr.image_bpp);
+    stream.write_uint8(hdr.image_descriptor);
 }
 
 bool is_valid_header(const Header& header)

--- a/openglyph/src/io/chunk_reader.cpp
+++ b/openglyph/src/io/chunk_reader.cpp
@@ -100,8 +100,8 @@ void ChunkReader::read_next()
         throw khepri::io::InvalidFormatError();
     }
 
-    auto id   = m_stream.read_uint();
-    auto size = m_stream.read_uint();
+    auto id   = m_stream.read_uint32();
+    auto size = m_stream.read_uint32();
     bool data = ((size & 0x80000000u) == 0);
     pos += 8;
     size = (size & 0x7fffffffu);


### PR DESCRIPTION
This PR changes the names of the stream integer read/write functions for increased clarity in integer size.