### PR TITLE
ci: add commit title check to CI builds

### DIFF
--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -1,0 +1,20 @@
+name: check-conventional-commits
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened, edited]
+
+  workflow_dispatch:
+
+jobs:
+  validate-pr-title:
+    name: Check Conventional Commit title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Conventional Commit title
+        uses:  ytanikin/pr-conventional-commits@1.4.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'true'


### PR DESCRIPTION
This change adds a check in CI to see if the commit title meets Conventional Commit rules.