### PR TITLE
ci: speed up builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,9 @@ jobs:
   build:
     needs: [formatting-check]
 
-    # Use Windows 2022 specifically to get VS2022, which allows downloading pre-built binaries from conan center, rather than rebuilding them in CI.
-    runs-on: windows-2022
+    # Use Windows 2019 specifically to get VS2019, which allows downloading pre-built binaries
+    # from conan center (compiler.version=193), rather than rebuilding them in CI.
+    runs-on: windows-2019
     strategy:
       matrix:
         build_type: ['Debug','Release']


### PR DESCRIPTION
Speed up the builds by switching to an older GitHub runner: windows-2019. The previous runner, windows-2022, had its Visual Studio updated so `compiler.version` changed from 193 to 194. This caused some Conan packages to be built locally instead of downloaded. windows-2019 still has `compiler.version=193`.