### PR TITLE
fix: shader creation can fail silenty

### DIFF
--- a/data-extra/Data/XML/Materials.xml
+++ b/data-extra/Data/XML/Materials.xml
@@ -3,16 +3,20 @@
     <!-- Note: the order of (non-texture) parameters in a material must be the same as in its shader's constant buffer -->
 
     <!-- Special material for GUI rendering. See GUIDialogs.xml -->
+    <!--
     <Material Name="GUI" AlphaBlend="blend_src" DepthEnable="false" ScissorEnable="true">
         <Shader>GUI</Shader>
         <Param Name="BaseTexture" Type="texture"></Param>
     </Material>
+    -->
 
     <!-- Special material for Font rendering. See GUIDialogs.xml -->
+    <!--
     <Material Name="Font" AlphaBlend="blend_src" DepthEnable="false">
         <Shader>GUI</Shader>
         <Param Name="BaseTexture" Type="texture"></Param>
     </Material>
+    -->
 
     <Material Name="MeshBumpColorize">
         <Shader>MeshBumpColorize</Shader>

--- a/khepri/src/renderer/diligent/renderer.cpp
+++ b/khepri/src/renderer/diligent/renderer.cpp
@@ -5,6 +5,7 @@
 #include <khepri/log/log.hpp>
 #include <khepri/renderer/camera.hpp>
 #include <khepri/renderer/diligent/renderer.hpp>
+#include <khepri/renderer/exceptions.hpp>
 
 #ifdef _MSC_VER
 #include <EngineFactoryD3D11.h>
@@ -336,7 +337,16 @@ public:
 
         auto shader           = std::make_unique<Shader>();
         shader->vertex_shader = create_shader_object(path.string(), SHADER_TYPE_VERTEX, "vs_main");
-        shader->pixel_shader  = create_shader_object(path.string(), SHADER_TYPE_PIXEL, "ps_main");
+        if (!shader->vertex_shader) {
+            throw khepri::renderer::Error("Failed to create vertex shader from file: " +
+                                          path.string());
+        }
+
+        shader->pixel_shader = create_shader_object(path.string(), SHADER_TYPE_PIXEL, "ps_main");
+        if (!shader->pixel_shader) {
+            throw khepri::renderer::Error("Failed to create pixel shader from file: " +
+                                          path.string());
+        }
         return shader;
     }
 


### PR DESCRIPTION
If the vertex or pixel shader cannot be loaded, the shader object is still created, which causes an assertion later on, when it's used. This change throws an exception if the shader cannot be loaded.

It also fixes Materials.xml to comment out some nonexistent shaders for future use.