### PR TITLE
chore: fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,23 +1,44 @@
 ---
-Checks: '
+# Note: we need to disable some checks that are not compatible with our codebase
+Checks: [
     -*,
     bugprone-*,
-    -bugprone-easily-swappable-parameters,
     cert-*,
     clang-analyzer-*,
     concurrency-*,
     cppcoreguidelines-*,
     misc-*,
-    -misc-no-recursion,
     modernize-*,
-    -modernize-use-trailing-return-type,
     performance-*,
     portability-*,
     readability-*,
-    -readability-identifier-length
-'
+
+    # This is overly strict and prevents common patterns dealing with width, length, x, y, and so on.
+    -bugprone-easily-swappable-parameters,
+
+    # Magic numbers aren't properly handled by clang-tidy, even though we could ignore a lot of them.
+    -cppcoreguidelines-avoid-magic-numbers,
+    -readability-magic-numbers,
+
+    # We have code that does dynamic indexing into arrays. It's easily provable that
+    # it doesn't go out of bounds, but clang-tidy doesn't understand that.
+    -cppcoreguidelines-pro-bounds-constant-array-index,
+
+    # The include cleaner is more trouble than it's worth.
+    -misc-include-cleaner,
+
+    # We use recursion. This isn't safety-critical code.
+    -misc-no-recursion,
+
+    # We don't care for the stylistic trailing return type pattern.
+    -modernize-use-trailing-return-type,
+
+    # We use names like x and y in places, so this check isn't useful.
+    -readability-identifier-length,
+]
 
 CheckOptions:
+    - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: true }
     - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
     - { key: readability-identifier-naming.EnumCase, value: CamelCase }
     - { key: readability-identifier-naming.ClassCase, value: CamelCase }
@@ -28,5 +49,4 @@ CheckOptions:
     - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_ }
     - { key: readability-identifier-naming.GlobalConstantCase, value: UPPER_CASE }
     - { key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic, value: true }
-    - { key: readability-magic-numbers.IgnoredIntegerValues, value: {0,1,2,3,4,8,16,24,32} }
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -54,6 +54,10 @@ class OpenEawConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+
+        # To enable static analyses tools like clang-tidy
+        tc.cache_variables["CMAKE_EXPORT_COMPILE_COMMANDS"] = "ON"
+
         # Propagate version info into CMake
         version_info = self._parse_version(self.version)
         if version_info:

--- a/khepri/include/khepri/application/current_directory.hpp
+++ b/khepri/include/khepri/application/current_directory.hpp
@@ -6,6 +6,8 @@ namespace khepri::application {
 
 /**
  * @brief Get the Current ("Working") Directory
+ *
+ * @throw khepri::Error if the current directory cannot be determined.
  */
 std::filesystem::path get_current_directory();
 

--- a/khepri/include/khepri/application/exceptions.hpp
+++ b/khepri/include/khepri/application/exceptions.hpp
@@ -36,7 +36,7 @@ public:
      * of the callable.
      */
     template <typename Callable>
-    auto invoke(Callable&& callable)
+    auto invoke(const Callable& callable)
     {
         using ResultType = decltype(callable());
         if constexpr (std::is_same_v<ResultType, void>) {

--- a/khepri/include/khepri/application/window.hpp
+++ b/khepri/include/khepri/application/window.hpp
@@ -5,6 +5,7 @@
 #include <khepri/math/vector2.hpp>
 
 #include <any>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -22,7 +23,7 @@ class Window final
 {
 public:
     /// Identifies a mouse button
-    enum class MouseButton
+    enum class MouseButton : std::uint8_t
     {
         /// The left mouse button
         left,
@@ -31,7 +32,7 @@ public:
     };
 
     /// Identifies a mouse button action
-    enum class MouseButtonAction
+    enum class MouseButtonAction : std::uint8_t
     {
         /// The mouse button was pressed
         pressed,
@@ -95,12 +96,12 @@ public:
      * In practice, this is true for OpenGL contexts. Otherwise, the renderer should be used to
      * present the rendered content.
      */
-    [[nodiscard]] bool use_swap_buffers() const;
+    [[nodiscard]] static bool use_swap_buffers();
 
     /**
      * Swaps the front and back buffers of the window.
      */
-    void swap_buffers() const;
+    void swap_buffers();
 
     /**
      * Adds a listener for "window size changed" events.

--- a/khepri/include/khepri/font/font_face.hpp
+++ b/khepri/include/khepri/font/font_face.hpp
@@ -24,7 +24,12 @@ public:
      * Constructs the font face
      */
     FontFace(const FontFaceDesc& font_face_desc);
+    FontFace(const FontFace&) = default;
+    FontFace(FontFace&&)      = default;
     ~FontFace();
+
+    FontFace& operator=(const FontFace&) = default;
+    FontFace& operator=(FontFace&&)      = default;
 
     /**
      * Creates a font.

--- a/khepri/include/khepri/io/container_stream.hpp
+++ b/khepri/include/khepri/io/container_stream.hpp
@@ -2,6 +2,9 @@
 
 #include "stream.hpp"
 
+#include <cstddef>
+#include <cstdint>
+
 namespace khepri::io {
 
 /**
@@ -15,7 +18,7 @@ class ContainerStream final : public Stream
 {
 public:
     /// Mode to open files in
-    enum class OpenMode
+    enum class OpenMode : std::uint8_t
     {
         /// Open files in read-only mode
         read,

--- a/khepri/include/khepri/io/file.hpp
+++ b/khepri/include/khepri/io/file.hpp
@@ -4,6 +4,7 @@
 
 #include <gsl/gsl-lite.hpp>
 
+#include <cstdint>
 #include <cstdio>
 #include <filesystem>
 #include <memory>
@@ -11,7 +12,7 @@
 namespace khepri::io {
 
 /// Modes for dealing with files
-enum class OpenMode
+enum class OpenMode : std::uint8_t
 {
     read,       /// Opens an existing file for reading.
     read_write, /// Creates a new file for reading and writing.

--- a/khepri/include/khepri/io/stream.hpp
+++ b/khepri/include/khepri/io/stream.hpp
@@ -5,7 +5,7 @@
 
 namespace khepri::io {
 
-enum class SeekOrigin
+enum class SeekOrigin : std::uint8_t
 {
     begin,   ///< Seek from the beginning of the file.
     current, ///< Seek from the current position in the file.

--- a/khepri/include/khepri/log/log.hpp
+++ b/khepri/include/khepri/log/log.hpp
@@ -15,7 +15,7 @@ namespace khepri::log {
 // messing up the log timestamps.
 using Clock = std::chrono::steady_clock;
 
-enum class Severity
+enum class Severity : std::uint8_t
 {
     debug,
     info,

--- a/khepri/include/khepri/math/bits.hpp
+++ b/khepri/include/khepri/math/bits.hpp
@@ -45,7 +45,7 @@ inline unsigned int bitcount(std::uint64_t value)
 }
 
 /// Returns the first power of two equal to or greater than the value
-inline constexpr std::uint32_t ceil_power_of_two(std::uint32_t value)
+constexpr std::uint32_t ceil_power_of_two(std::uint32_t value)
 {
     // From Bit Twiddling Hacks:
     // "It works by copying the highest set bit to all of the lower bits, and then adding one,

--- a/khepri/include/khepri/math/color_rgba.hpp
+++ b/khepri/include/khepri/math/color_rgba.hpp
@@ -148,7 +148,7 @@ inline ColorRGBA operator*(const ColorRGBA& c1, const ColorRGBA& c2) noexcept
     return {c1.r * c2.r, c1.g * c2.g, c1.b * c2.b, c1.a * c2.a};
 }
 
-inline constexpr ColorRGB::ColorRGB(const ColorRGBA& c) noexcept : r(c.r), g(c.g), b(c.b) {}
+constexpr ColorRGB::ColorRGB(const ColorRGBA& c) noexcept : r(c.r), g(c.g), b(c.b) {}
 
 /**
  * \brief Clamps each component of a color between two extremes

--- a/khepri/include/khepri/math/color_srgb.hpp
+++ b/khepri/include/khepri/math/color_srgb.hpp
@@ -100,7 +100,7 @@ public:
 };
 #pragma pack(pop)
 
-inline constexpr ColorRGB::ColorRGB(const ColorSRGB& c) noexcept
+constexpr ColorRGB::ColorRGB(const ColorSRGB& c) noexcept
     : r(ColorSRGB::srgb_to_linear(static_cast<float>(c.r) /
                                   std::numeric_limits<ColorSRGB::ComponentType>::max()))
     , g(ColorSRGB::srgb_to_linear(static_cast<float>(c.g) /

--- a/khepri/include/khepri/math/frustum.hpp
+++ b/khepri/include/khepri/math/frustum.hpp
@@ -56,9 +56,9 @@ public:
      */
     [[nodiscard]] Frustum transform(const Matrix& transform) const noexcept
     {
-        return Frustum(m_left.transform(transform), m_right.transform(transform),
-                       m_top.transform(transform), m_bottom.transform(transform),
-                       m_near.transform(transform), m_far.transform(transform));
+        return {m_left.transform(transform), m_right.transform(transform),
+                m_top.transform(transform),  m_bottom.transform(transform),
+                m_near.transform(transform), m_far.transform(transform)};
     }
 
     /**

--- a/khepri/include/khepri/math/interpolator.hpp
+++ b/khepri/include/khepri/math/interpolator.hpp
@@ -25,7 +25,7 @@ public:
      *
      * \note x is clamped to the input range for the interpolator.
      */
-    virtual double interpolate(double x) const noexcept = 0;
+    [[nodiscard]] virtual double interpolate(double x) const noexcept = 0;
 };
 
 /**
@@ -62,7 +62,7 @@ public:
     explicit StepInterpolator(gsl::span<const Point> points);
 
     /// \see Interpolator::interpolate
-    double interpolate(double x) const noexcept override;
+    [[nodiscard]] double interpolate(double x) const noexcept override;
 
 private:
     std::vector<Point> m_points;
@@ -102,7 +102,7 @@ public:
     explicit LinearInterpolator(gsl::span<const Point> points);
 
     /// \see Interpolator::interpolate
-    double interpolate(double x) const noexcept override;
+    [[nodiscard]] double interpolate(double x) const noexcept override;
 
 private:
     std::vector<Point> m_points;
@@ -144,7 +144,7 @@ public:
     explicit CosineInterpolator(gsl::span<const Point> points);
 
     /// \see Interpolator::interpolate
-    double interpolate(double x) const noexcept override;
+    [[nodiscard]] double interpolate(double x) const noexcept override;
 
 private:
     std::vector<Point> m_points;
@@ -186,7 +186,7 @@ public:
     explicit CubicInterpolator(gsl::span<const Point> points);
 
     /// \see Interpolator::interpolate
-    double interpolate(double x) const noexcept override;
+    [[nodiscard]] double interpolate(double x) const noexcept override;
 
 private:
     struct Segment
@@ -195,7 +195,7 @@ private:
         double          min_x;
     };
 
-    std::vector<Segment> create_segments(gsl::span<const Point> points);
+    static std::vector<Segment> create_segments(gsl::span<const Point> points);
 
     std::vector<Segment> m_segments;
 

--- a/khepri/include/khepri/math/math.hpp
+++ b/khepri/include/khepri/math/math.hpp
@@ -15,9 +15,9 @@ static constexpr double PI = 3.1415926535897932384626433832795;
  * extrapolation.
  */
 template <typename T>
-inline T lerp(const T& v0, const T& v1, float t) noexcept
+inline T lerp(const T& v0, const T& v1, double t) noexcept
 {
-    return T(v1 * t + v0 * (1.0f - t));
+    return T(v1 * t + v0 * (1.0 - t));
 }
 
 /**
@@ -36,7 +36,13 @@ inline T lerp(const T& v0, const T& v1, float t) noexcept
 template <typename T, typename U>
 constexpr T clamp(const T& val, const U& min, const U& max) noexcept
 {
-    return (val <= min) ? T{min} : (val >= max) ? T{max} : val;
+    if (val <= min) {
+        return T{min};
+    }
+    if (val >= max) {
+        return T{max};
+    }
+    return val;
 }
 
 /**

--- a/khepri/include/khepri/math/matrix.hpp
+++ b/khepri/include/khepri/math/matrix.hpp
@@ -93,14 +93,14 @@ public:
 
     /// Returns a column of the matrix
     /// \throws std::out_of_range if \a col is not between 0 and 3, inclusive.
-    constexpr BasicVector4<ComponentType> col(std::size_t col) const noexcept
+    [[nodiscard]] constexpr BasicVector4<ComponentType> col(std::size_t col) const noexcept
     {
         return m_cols.at(col);
     }
 
     /// Returns a row of the matrix
     /// \throws std::out_of_range if \a row is not between 0 and 3, inclusive.
-    constexpr BasicVector4<ComponentType> row(std::size_t row) const noexcept
+    [[nodiscard]] constexpr BasicVector4<ComponentType> row(std::size_t row) const noexcept
     {
         return {m_cols[0][row], m_cols[1][row], m_cols[2][row], m_cols[3][row]};
     }
@@ -375,10 +375,11 @@ template <typename T>
 BasicMatrix<T> operator*(const BasicMatrix<T>& m1, const BasicMatrix<T>& m2) noexcept
 {
     BasicMatrix<T> m;
-    for (std::size_t i = 0; i < 4; ++i)
+    for (std::size_t i = 0; i < 4; ++i) {
         for (std::size_t j = 0; j < 4; ++j) {
             m(i, j) = dot(m1.row(i), m2.col(j));
         }
+    }
     return m;
 }
 

--- a/khepri/include/khepri/math/plane.hpp
+++ b/khepri/include/khepri/math/plane.hpp
@@ -5,6 +5,7 @@
 #include "vector3.hpp"
 
 #include <cassert>
+#include <cmath>
 
 namespace khepri {
 
@@ -41,21 +42,21 @@ public:
     /// Returns a copy of this plane, transformed by \a transform
     [[nodiscard]] Plane transform(const Matrix& transform) const noexcept
     {
-        return Plane(transform.transform_coord(m_position), normalize(m_normal * transform));
+        return {transform.transform_coord(m_position), normalize(m_normal * transform)};
     }
 
     //! Returns the orthogonal distance between the point and the plane,
     //! where positive is "above" the plane (same direction as normal vector),
     //! and negative is "below".
-    [[nodiscard]] float signed_distance(const Vector3& point) const noexcept
+    [[nodiscard]] double signed_distance(const Vector3& point) const noexcept
     {
         return dot(point - m_position, m_normal);
     }
 
     //! Returns the absolute, orthogonal distance between the point and the plane.
-    [[nodiscard]] float distance(const Vector3& point) const noexcept
+    [[nodiscard]] double distance(const Vector3& point) const noexcept
     {
-        return abs(signed_distance(point));
+        return std::abs(signed_distance(point));
     }
 
 private:

--- a/khepri/include/khepri/math/point.hpp
+++ b/khepri/include/khepri/math/point.hpp
@@ -43,13 +43,13 @@ using Pointf = BasicPoint<float>;
 using Pointi = BasicPoint<long>;
 
 template <typename T, typename U>
-inline constexpr bool operator==(const BasicPoint<T>& p1, const BasicPoint<U>& p2) noexcept
+constexpr bool operator==(const BasicPoint<T>& p1, const BasicPoint<U>& p2) noexcept
 {
     return p1.x == p2.x && p1.y == p2.y;
 }
 
 template <typename T, typename U>
-inline constexpr bool operator!=(const BasicPoint<T>& p1, const BasicPoint<U>& p2) noexcept
+constexpr bool operator!=(const BasicPoint<T>& p1, const BasicPoint<U>& p2) noexcept
 {
     return !(p1 == p2);
 }

--- a/khepri/include/khepri/math/polynomial.hpp
+++ b/khepri/include/khepri/math/polynomial.hpp
@@ -27,7 +27,7 @@ struct Polynomial
     /**
      * @brief Samples the polynomial for given \a x.
      */
-    [[nodiscard]] double sample(double x) const noexcept
+    [[nodiscard]] constexpr double sample(double x) const noexcept
     {
         // Use Horner's rule for polynomial evaluation
         double y = coefficients[Degree];
@@ -44,13 +44,14 @@ struct Polynomial
      * except for a polynomial of degree 0: it's derivative is also a 0-degree polynomial (f(x) = 0
      * to be precise).
      */
-    Polynomial<std::max<std::size_t>(Degree, 1) - 1> derivative() const noexcept
+    [[nodiscard]] constexpr Polynomial<std::max<std::size_t>(Degree, 1) - 1>
+    derivative() const noexcept
     {
         if constexpr (Degree == 0) {
             // The derivative of a constant is 0.
             return {{0}};
         } else {
-            Polynomial<Degree - 1> p;
+            Polynomial<Degree - 1> p{};
             for (std::size_t i = 1; i <= Degree; ++i) {
                 p.coefficients[i - 1] = i * coefficients[i];
             }

--- a/khepri/include/khepri/math/quaternion.hpp
+++ b/khepri/include/khepri/math/quaternion.hpp
@@ -40,8 +40,7 @@ public:
     }
 
     /// Implicitly constructs the quaternion from another quaternion with a
-    /// non-narrowing-convertible
-    /// component
+    /// non-narrowing-convertible component
     template <typename U,
               typename std::enable_if_t<std::is_convertible_v<U, ComponentType> &&
                                             !is_narrowing_conversion_v<U, ComponentType>,
@@ -118,8 +117,9 @@ public:
             return z;
         case 3:
             return w;
+        default:
+            throw std::out_of_range("invalid BasicQuaternion subscript");
         }
-        throw std::out_of_range("invalid BasicQuaternion subscript");
     }
 
     /**
@@ -140,8 +140,9 @@ public:
             return z;
         case 3:
             return w;
+        default:
+            throw std::out_of_range("invalid BasicQuaternion subscript");
         }
-        throw std::out_of_range("invalid BasicQuaternion subscript");
     }
 
     /// Normalizes the quaternion
@@ -215,9 +216,12 @@ public:
      */
     static BasicQuaternion from_euler(ComponentType x, ComponentType y, ComponentType z) noexcept
     {
-        const auto c1 = std::cos(-x / 2), s1 = std::sin(-x / 2);
-        const auto c2 = std::cos(-y / 2), s2 = std::sin(-y / 2);
-        const auto c3 = std::cos(-z / 2), s3 = std::sin(-z / 2);
+        const auto c1 = std::cos(-x / 2);
+        const auto s1 = std::sin(-x / 2);
+        const auto c2 = std::cos(-y / 2);
+        const auto s2 = std::sin(-y / 2);
+        const auto c3 = std::cos(-z / 2);
+        const auto s3 = std::sin(-z / 2);
         return {s1 * c2 * c3 + c1 * s2 * s3, c1 * s2 * c3 - s1 * c2 * s3,
                 c1 * c2 * s3 + s1 * s2 * c3, c1 * c2 * c3 - s1 * s2 * s3};
     }

--- a/khepri/include/khepri/math/ray.hpp
+++ b/khepri/include/khepri/math/ray.hpp
@@ -44,7 +44,7 @@ public:
     /// Returns a copy of this ray, transformed by \a transform
     [[nodiscard]] Ray transform(const Matrix& transform) const noexcept
     {
-        return Ray(transform.transform_coord(m_start), normalize(m_direction * transform));
+        return {transform.transform_coord(m_start), normalize(m_direction * transform)};
     }
 
     /**
@@ -54,24 +54,24 @@ public:
      * Returns a negative number if there is no intersection or if the starting point is inside the
      * sphere.
      */
-    [[nodiscard]] float intersect_distance(const Sphere& sphere) const noexcept
+    [[nodiscard]] double intersect_distance(const Sphere& sphere) const noexcept
     {
         // vector from ray origin (O) to sphere center (C)
-        Vector3 OC = sphere.center() - m_start;
+        const Vector3 OC = sphere.center() - m_start;
 
         // Distance along ray of orthogonal projection (P) of sphere center (C)
-        float dist_P = dot(OC, m_direction);
+        const double dist_P = dot(OC, m_direction);
 
         // Sphere center must be in front of ray start, or no intersection
-        if (dist_P >= 0.0F) {
+        if (dist_P >= 0.0) {
             // Squared distance from sphere center (C) to ray (P)
-            float dist_to_ray_sq = OC.length_sq() - dist_P * dist_P;
+            const double dist_to_ray_sq = OC.length_sq() - dist_P * dist_P;
 
             // P must be inside of sphere, or no intersection
-            float radius_sq = sphere.radius_sq();
+            const double radius_sq = sphere.radius_sq();
             if (dist_to_ray_sq <= radius_sq) {
                 // Distance along ray of intersection with sphere
-                float d = dist_P - sqrt(radius_sq - dist_to_ray_sq);
+                const double d = dist_P - sqrt(radius_sq - dist_to_ray_sq);
 
                 // Intersection must be in front of ray, or no intersection
                 if (d >= 0.0) {

--- a/khepri/include/khepri/math/rect.hpp
+++ b/khepri/include/khepri/math/rect.hpp
@@ -31,10 +31,11 @@ struct Rect
  * The rectangle's width and height are exclusive: the positions described by x + width or y +
  * height are considered to be outside of the rectangle.
  */
-inline constexpr bool inside(const Point& p, const Rect& r)
+constexpr bool inside(const Point& p, const Rect& r)
 {
-    return p.x >= r.x && p.y >= r.y && static_cast<unsigned long>(p.x - r.x) < r.width &&
-           static_cast<unsigned long>(p.y - r.y) < r.height;
+    return static_cast<long>(p.x) >= r.x && static_cast<long>(p.y) >= r.y &&
+           static_cast<unsigned long>(static_cast<long>(p.x) - r.x) < r.width &&
+           static_cast<unsigned long>(static_cast<long>(p.y) - r.y) < r.height;
 }
 
 } // namespace khepri

--- a/khepri/include/khepri/math/size.hpp
+++ b/khepri/include/khepri/math/size.hpp
@@ -14,12 +14,12 @@ struct Size
     unsigned long height;
 };
 
-inline constexpr bool operator==(const Size& s1, const Size& s2) noexcept
+constexpr bool operator==(const Size& s1, const Size& s2) noexcept
 {
     return s1.width == s2.width && s1.height == s2.height;
 }
 
-inline constexpr bool operator!=(const Size& s1, const Size& s2) noexcept
+constexpr bool operator!=(const Size& s1, const Size& s2) noexcept
 {
     return !(s1 == s2);
 }

--- a/khepri/include/khepri/math/sphere.hpp
+++ b/khepri/include/khepri/math/sphere.hpp
@@ -13,7 +13,7 @@ class Sphere final
 {
 public:
     /// Constructs a sphere from a center and radius
-    Sphere(const Vector3& center, float radius) noexcept : m_center(center), m_radius(radius)
+    Sphere(const Vector3& center, double radius) noexcept : m_center(center), m_radius(radius)
     {
         assert(radius >= 0.0F);
     }
@@ -25,13 +25,13 @@ public:
     }
 
     /// Returns the radius of the sphere
-    [[nodiscard]] float radius() const noexcept
+    [[nodiscard]] double radius() const noexcept
     {
         return m_radius;
     }
 
     /// Returns squared radius of the sphere
-    [[nodiscard]] float radius_sq() const noexcept
+    [[nodiscard]] double radius_sq() const noexcept
     {
         return m_radius * m_radius;
     }
@@ -45,18 +45,18 @@ public:
     /// Translates (moves) the sphere by \a v
     [[nodiscard]] Sphere translate(const Vector3& v) const noexcept
     {
-        return Sphere(m_center + v, m_radius);
+        return {m_center + v, m_radius};
     }
 
     /// Scales the sphere by \a scale
-    [[nodiscard]] Sphere scale(float scale) const noexcept
+    [[nodiscard]] Sphere scale(double scale) const noexcept
     {
-        return Sphere(m_center, m_radius * scale);
+        return {m_center, m_radius * scale};
     }
 
 private:
     Vector3 m_center;
-    float   m_radius;
+    double  m_radius;
 };
 
 } // namespace khepri

--- a/khepri/include/khepri/math/spline.hpp
+++ b/khepri/include/khepri/math/spline.hpp
@@ -44,7 +44,7 @@ public:
      *
      * @note the returned span is valid until the spline is destroyed.
      */
-    gsl::span<const Vector3> points() const noexcept
+    [[nodiscard]] gsl::span<const Vector3> points() const noexcept
     {
         return m_points;
     }

--- a/khepri/include/khepri/math/vector3.hpp
+++ b/khepri/include/khepri/math/vector3.hpp
@@ -236,7 +236,7 @@ public:
     /// Normalizes the vector
     void normalize() noexcept
     {
-        ComponentType inv_length = 1.0F / length();
+        const auto inv_length = 1.0F / length();
         x *= inv_length;
         y *= inv_length;
         z *= inv_length;

--- a/khepri/include/khepri/renderer/camera.hpp
+++ b/khepri/include/khepri/renderer/camera.hpp
@@ -4,6 +4,7 @@
 #include <khepri/math/matrix.hpp>
 #include <khepri/math/vector3.hpp>
 
+#include <cstdint>
 #include <tuple>
 
 namespace khepri::renderer {
@@ -21,7 +22,7 @@ class Camera final
 {
 public:
     /// The type of camera
-    enum class Type
+    enum class Type : std::uint8_t
     {
         orthographic,
         perspective,
@@ -30,25 +31,25 @@ public:
     /// The camera properties
     struct Properties
     {
-        Type    type{};     ///< The type of the camera
-        Vector3 position{}; ///< The world-space position of the camera
-        Vector3 target{};   ///< The world-space vector of the target of the camera
-        Vector3 up{};       ///< The world-space vector corresponding to 'up' on the camera
-        double  fov{};      ///< Vertical field of view in radians (perspective cameras only)
-        double  width{};    ///< Width, in world units, of the camera (orthographic cameras only)
-        double  aspect{};   ///< Aspect ratio (Width / Height) of the render viewport
-        double  znear{};    ///< Distance, in camera-space units, of the near clip plane
-        double  zfar{};     ///< Distance, in camera-space units, of the far clip plane
+        Type    type{};   ///< The type of the camera
+        Vector3 position; ///< The world-space position of the camera
+        Vector3 target;   ///< The world-space vector of the target of the camera
+        Vector3 up;       ///< The world-space vector corresponding to 'up' on the camera
+        double  fov{};    ///< Vertical field of view in radians (perspective cameras only)
+        double  width{};  ///< Width, in world units, of the camera (orthographic cameras only)
+        double  aspect{}; ///< Aspect ratio (Width / Height) of the render viewport
+        double  znear{};  ///< Distance, in camera-space units, of the near clip plane
+        double  zfar{};   ///< Distance, in camera-space units, of the far clip plane
     };
 
     /// Collection of useful matrices derived from the camera properties
     struct Matrices
     {
-        Matrixf view{};          ///< World-to-Camera-space matrix
-        Matrixf view_inv{};      ///< inverse of m_view
-        Matrixf projection{};    ///< Camera-to-Screen-space matrix
-        Matrixf view_proj{};     ///< m_view * m_proj
-        Matrixf view_proj_inv{}; ///< inverse of m_view_proj
+        Matrixf view;          ///< World-to-Camera-space matrix
+        Matrixf view_inv;      ///< inverse of m_view
+        Matrixf projection;    ///< Camera-to-Screen-space matrix
+        Matrixf view_proj;     ///< m_view * m_proj
+        Matrixf view_proj_inv; ///< inverse of m_view_proj
     };
 
     /**

--- a/khepri/include/khepri/renderer/diligent/renderer.hpp
+++ b/khepri/include/khepri/renderer/diligent/renderer.hpp
@@ -28,7 +28,7 @@ public:
      * - Linux:   a std::tuple<void*, std::uint32_t> is expected where the first element is
      *            the X11 display pointer and the second element is the X11 window ID.
      */
-    Renderer(std::any window);
+    Renderer(const std::any& window);
     ~Renderer() override;
 
     Renderer(const Renderer&)            = delete;

--- a/khepri/include/khepri/renderer/io/serialize.hpp
+++ b/khepri/include/khepri/renderer/io/serialize.hpp
@@ -60,7 +60,7 @@ struct SerializeTraits<renderer::ModelDesc>
     static renderer::ModelDesc deserialize(Deserializer& d)
     {
         auto meshes = d.read<std::vector<renderer::MeshDesc>>();
-        return renderer::ModelDesc(std::move(meshes));
+        return {std::move(meshes)};
     }
 };
 

--- a/khepri/include/khepri/renderer/io/texture.hpp
+++ b/khepri/include/khepri/renderer/io/texture.hpp
@@ -18,7 +18,7 @@ TextureDesc load_texture(khepri::io::Stream& stream);
 /**
  * Possible texture formats for #save_texture
  */
-enum TextureFormat
+enum TextureFormat : std::uint8_t
 {
     /**
      * TrueVision TARGA.

--- a/khepri/include/khepri/renderer/material.hpp
+++ b/khepri/include/khepri/renderer/material.hpp
@@ -26,7 +26,7 @@ public:
         /// Name of the parameter
         std::string name;
         /// Value of the parameter
-        ParamValue value{};
+        ParamValue value;
     };
 
     Material()          = default;

--- a/khepri/include/khepri/renderer/material_desc.hpp
+++ b/khepri/include/khepri/renderer/material_desc.hpp
@@ -31,7 +31,7 @@ namespace khepri::renderer {
 struct MaterialDesc
 {
     /// The type of face culling
-    enum class CullMode
+    enum class CullMode : std::uint8_t
     {
         none,
         back,
@@ -39,7 +39,7 @@ struct MaterialDesc
     };
 
     /// The type of alpha blending
-    enum class AlphaBlendMode
+    enum class AlphaBlendMode : std::uint8_t
     {
         /// Do not alpha blend.
         none,
@@ -52,7 +52,7 @@ struct MaterialDesc
     };
 
     /// Comparison function for depth or stencil buffer operations
-    enum class ComparisonFunc
+    enum class ComparisonFunc : std::uint8_t
     {
         never,
         less,

--- a/khepri/include/khepri/renderer/renderer.hpp
+++ b/khepri/include/khepri/renderer/renderer.hpp
@@ -36,7 +36,7 @@ class Renderer
 {
 public:
     /// Flags for #clear()
-    enum ClearFlags : int
+    enum ClearFlags : std::uint8_t
     {
         clear_rendertarget = 1,
         clear_depth        = 2,

--- a/khepri/include/khepri/renderer/texture_desc.hpp
+++ b/khepri/include/khepri/renderer/texture_desc.hpp
@@ -12,7 +12,7 @@ namespace khepri::renderer {
 /**
  * Dimensionality of a texture
  */
-enum class TextureDimension
+enum class TextureDimension : std::uint8_t
 {
     /**
      * One-dimensional texture.
@@ -42,7 +42,7 @@ enum class TextureDimension
 /**
  * The format of pixel data in a texture
  */
-enum class PixelFormat
+enum class PixelFormat : std::uint8_t
 {
     /**
      * Four-component unsigned-normalized-integer format with 8 bits for R, G, B and A. Color data

--- a/khepri/include/khepri/scene/scene.hpp
+++ b/khepri/include/khepri/scene/scene.hpp
@@ -18,10 +18,10 @@ public:
     Scene()          = default;
     virtual ~Scene() = default;
 
-    Scene(const Scene&)            = delete;
-    Scene(Scene&&)                 = delete;
-    Scene& operator=(const Scene&) = delete;
-    Scene& operator=(Scene&&)      = delete;
+    Scene(const Scene&)                = delete;
+    Scene(Scene&&) noexcept            = delete;
+    Scene& operator=(const Scene&)     = delete;
+    Scene& operator=(Scene&&) noexcept = delete;
 
     /// Returns the objects in the scene
     [[nodiscard]] const auto& objects() const noexcept

--- a/khepri/include/khepri/utility/enum.hpp
+++ b/khepri/include/khepri/utility/enum.hpp
@@ -2,31 +2,32 @@
 
 #include <type_traits>
 
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
 constexpr T operator~(T a)
 {
-    return static_cast<T>(~static_cast<typename std::underlying_type<T>::type>(a));
+    return static_cast<T>(~static_cast<typename std::underlying_type_t<T>>(a));
 }
 
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
 constexpr T operator|(T a, T b)
 {
-    return static_cast<T>(static_cast<typename std::underlying_type<T>::type>(a) |
-                          static_cast<typename std::underlying_type<T>::type>(b));
+    return static_cast<T>(static_cast<typename std::underlying_type_t<T>>(a) |
+                          static_cast<typename std::underlying_type_t<T>>(b));
 }
 
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
 constexpr T operator&(T a, T b)
 {
-    return static_cast<T>(static_cast<typename std::underlying_type<T>::type>(a) &
-                          static_cast<typename std::underlying_type<T>::type>(b));
+    return static_cast<T>(static_cast<typename std::underlying_type_t<T>>(a) &
+                          static_cast<typename std::underlying_type_t<T>>(b));
 }
 
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
 constexpr T operator^(T a, T b)
 {
-    return static_cast<T>(static_cast<typename std::underlying_type<T>::type>(a) ^
-                          static_cast<typename std::underlying_type<T>::type>(b));
+    return static_cast<T>(static_cast<typename std::underlying_type_t<T>>(a) ^
+                          static_cast<typename std::underlying_type_t<T>>(b));
 }
 
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
@@ -46,3 +47,4 @@ constexpr T& operator^=(T& a, T b)
 {
     return a = a ^ b;
 }
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/khepri/include/khepri/utility/string.hpp
+++ b/khepri/include/khepri/utility/string.hpp
@@ -52,7 +52,7 @@ public:
     /// Checks if the first string-like argument is lexicographically less-than the second
     /// string-like argument
     template <typename T, typename U>
-    bool operator()(T&& t, U&& u) const noexcept
+    bool operator()(const T& t, const U& u) const noexcept
     {
         // Do not allow T or U to be character strings or literals.
         // Character pointers do not have std::begin/std::end and character literals's length

--- a/khepri/include/khepri/utility/type_traits.hpp
+++ b/khepri/include/khepri/utility/type_traits.hpp
@@ -12,24 +12,25 @@ constexpr std::false_type is_narrowing_conversion_helper(...);
 /**
  * \brief Determines if a conversion between two types is a narrowing conversion.
  *
- * is_narrowing_conversion::value is a constant expression with value 1 if the conversion from \a
+ * IsNarrowingConversion::value is a constant expression with value 1 if the conversion from \a
  * From to \a To is a narrowing conversion, 0 otherwise.
  *
  * \a From and \a To must be arithmetic types.
  */
 
 template <typename From, typename To, typename = void, typename = void>
-struct is_narrowing_conversion : std::true_type
+struct IsNarrowingConversion : std::true_type
 {};
 
 template <typename From, typename To>
-struct is_narrowing_conversion<
+struct IsNarrowingConversion<
     From, To, std::enable_if_t<std::is_arithmetic_v<From> && std::is_arithmetic_v<To>>,
     std::enable_if_t<decltype(detail::is_narrowing_conversion_helper<To>(
         {std::declval<From>()}))::value>> : std::false_type
 {};
 
 template <typename From, typename To>
-inline constexpr bool is_narrowing_conversion_v = is_narrowing_conversion<From, To>::value;
+// NOLINTNEXTLINE(readability-identifier-naming) -- snake_case to stay in line with std code
+inline constexpr bool is_narrowing_conversion_v = IsNarrowingConversion<From, To>::value;
 
 } // namespace khepri

--- a/khepri/src/application/console_logger.cpp
+++ b/khepri/src/application/console_logger.cpp
@@ -1,6 +1,8 @@
 #include <khepri/application/console_logger.hpp>
 #include <khepri/log/log.hpp>
 
+#include <fmt/format.h>
+
 #ifdef _MSC_VER
 #include <Windows.h>
 #endif
@@ -119,7 +121,7 @@ class ConsoleLogger::Impl final : private BaseLogger
 protected:
     void do_write(std::string_view data) noexcept override
     {
-        fwrite(data.data(), data.size(), 1, stderr);
+        static_cast<void>(fwrite(data.data(), data.size(), 1, stderr));
     }
 };
 #endif

--- a/khepri/src/application/current_directory.cpp
+++ b/khepri/src/application/current_directory.cpp
@@ -1,4 +1,5 @@
 #include <khepri/application/current_directory.hpp>
+#include <khepri/exceptions.hpp>
 
 #if defined(_MSC_VER)
 #include <Windows.h>
@@ -11,18 +12,31 @@
 #include <string>
 
 namespace khepri::application {
-
+namespace {
+struct FreeDeleter
+{
+    template <typename T>
+    void operator()(T* p) const
+    {
+        // NOLINTNEXTLINE
+        std::free(const_cast<std::remove_const_t<T>*>(p));
+    }
+};
+} // namespace
 std::filesystem::path get_current_directory()
 {
 #ifdef _MSC_VER
     std::array<CHAR, MAX_PATH> curdir{};
-    GetCurrentDirectoryA(MAX_PATH, curdir.data());
+    if (GetCurrentDirectoryA(MAX_PATH, curdir.data()) == 0) {
+        throw Error("Failed to get current directory");
+    }
     return curdir.data();
 #else
-    char*                 curdir_ = getcwd(nullptr, 0);
-    std::filesystem::path curdir  = curdir_;
-    std::free(curdir_);
-    return curdir;
+    const std::unique_ptr<char, FreeDeleter> curdir_(getcwd(nullptr, 0));
+    if (curdir_ == nullptr) {
+        throw Error("Failed to get current directory");
+    }
+    return curdir_.get();
 #endif
 }
 

--- a/khepri/src/application/exceptions.cpp
+++ b/khepri/src/application/exceptions.cpp
@@ -149,8 +149,10 @@ public:
     {
     }
 
-    ScopedTerminateHandler(const ScopedTerminateHandler&)            = delete;
-    ScopedTerminateHandler& operator=(const ScopedTerminateHandler&) = delete;
+    ScopedTerminateHandler(const ScopedTerminateHandler&)                = delete;
+    ScopedTerminateHandler(ScopedTerminateHandler&&) noexcept            = delete;
+    ScopedTerminateHandler& operator=(const ScopedTerminateHandler&)     = delete;
+    ScopedTerminateHandler& operator=(ScopedTerminateHandler&&) noexcept = delete;
 
     ~ScopedTerminateHandler()
     {
@@ -163,12 +165,12 @@ private:
 
 } // namespace
 
-ExceptionHandler::ExceptionHandler(std::string context) : m_context(context) {}
+ExceptionHandler::ExceptionHandler(std::string context) : m_context(std::move(context)) {}
 
 bool ExceptionHandler::invoke_void(const std::function<void()>& callable)
 {
     // Set the terminate handler
-    ScopedTerminateHandler terminate_handler([] {
+    const ScopedTerminateHandler terminate_handler([] {
         LOG.critical("std::terminate was called");
         std::abort();
     });

--- a/khepri/src/io/container_stream.cpp
+++ b/khepri/src/io/container_stream.cpp
@@ -1,6 +1,7 @@
 #include <khepri/io/container_stream.hpp>
 #include <khepri/io/exceptions.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <limits>

--- a/khepri/src/io/file.cpp
+++ b/khepri/src/io/file.cpp
@@ -1,5 +1,6 @@
 #include <khepri/io/exceptions.hpp>
 #include <khepri/io/file.hpp>
+#include <khepri/io/stream.hpp>
 
 #include <cassert>
 #include <cerrno>
@@ -44,7 +45,7 @@ long long File::seek(long long offset, SeekOrigin origin)
 
 File::File(const Path& path, OpenMode mode) : m_mode(mode)
 {
-    const char* modestr = "";
+    const char* modestr = nullptr;
     switch (mode) {
     default:
     case OpenMode::read:

--- a/khepri/src/io/stream.cpp
+++ b/khepri/src/io/stream.cpp
@@ -2,7 +2,10 @@
 #include <khepri/io/stream.hpp>
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace khepri::io {

--- a/khepri/src/log/log.cpp
+++ b/khepri/src/log/log.cpp
@@ -11,7 +11,7 @@ class SinkList
 public:
     void log(const RecordView& record) const
     {
-        std::lock_guard<std::mutex> lock(m_sink_mutex);
+        const std::lock_guard lock(m_sink_mutex);
         for (auto* sink : m_sinks) {
             sink->write(record);
         }
@@ -19,13 +19,13 @@ public:
 
     void add_sink(Sink* sink)
     {
-        std::lock_guard<std::mutex> lock(m_sink_mutex);
+        const std::lock_guard lock(m_sink_mutex);
         m_sinks.insert(sink);
     }
 
     void remove_sink(Sink* sink)
     {
-        std::lock_guard<std::mutex> lock(m_sink_mutex);
+        const std::lock_guard lock(m_sink_mutex);
         m_sinks.erase(sink);
     }
 

--- a/khepri/src/math/interpolator.cpp
+++ b/khepri/src/math/interpolator.cpp
@@ -25,7 +25,8 @@ void check_sorted(gsl::span<const Point> points)
 // Checks if two floating-point values are near enough to be considered equal
 bool is_near(double v1, double v2) noexcept
 {
-    return std::abs(v1 - v2) < 0.00000001;
+    static constexpr double MAX_DIFF = 0.00000001;
+    return std::abs(v1 - v2) < MAX_DIFF;
 }
 
 /// Returns the index of the last point that has an \a x member less than \a x.
@@ -35,18 +36,18 @@ std::size_t find_index(gsl::span<const Point> points, double x)
     assert(!points.empty());
     assert(x >= points.begin()->x && x <= points.rbegin()->x);
 
-    auto it = std::upper_bound(points.begin(), points.end(), x,
-                               [&](double value, auto& item) { return value < item.x; });
+    const auto* it = std::upper_bound(points.begin(), points.end(), x,
+                                      [&](double value, auto& item) { return value < item.x; });
     if (it == points.begin()) {
         // This shouldn't happen because x must be clamped to the points range, but perhaps
         // it's possible due to floating-point comparison weirdness. Anyway, we meant to
         // hit the next one.
-        ++it;
+        std::advance(it, 1);
     }
 
     // Return the index to the point on the _left_ of \a x such that
     // \a x is greater-than-or-equal to the returned point.
-    return std::distance(points.begin(), it - 1);
+    return std::distance(points.begin(), std::prev(it));
 }
 } // namespace
 

--- a/khepri/src/physics/collision_mesh.cpp
+++ b/khepri/src/physics/collision_mesh.cpp
@@ -12,8 +12,8 @@ namespace {
 double intersect_distance(const Ray& ray, const Vector3f& v0, const Vector3f& v1,
                           const Vector3f& v2)
 {
-    Vector3f e1 = v1 - v0;
-    Vector3f e2 = v2 - v0;
+    const Vector3f e1 = v1 - v0;
+    const Vector3f e2 = v2 - v0;
 
     // Calculate determinant
     auto h   = cross(ray.direction(), e2);
@@ -68,7 +68,7 @@ double CollisionMesh::intersect_distance(const Ray& ray) const
     bool   found        = false;
 
     for (std::size_t i = 0; i < m_indices.size(); i += 3) {
-        double distance =
+        const double distance =
             physics::intersect_distance(ray, m_vertices[m_indices[i + 0]],
                                         m_vertices[m_indices[i + 1]], m_vertices[m_indices[i + 2]]);
 

--- a/khepri/src/renderer/camera.cpp
+++ b/khepri/src/renderer/camera.cpp
@@ -13,10 +13,12 @@ Camera::Matrices Camera::create_matrices(const Properties& properties) noexcept
         Vector3f{properties.position}, Vector3f{properties.target}, Vector3f{properties.up});
     matrices.projection =
         (properties.type == Type::orthographic)
-            ? Matrixf::create_orthographic_projection(properties.width, properties.aspect,
-                                                      properties.znear, properties.zfar)
-            : Matrixf::create_perspective_projection(properties.fov, properties.aspect,
-                                                     properties.znear, properties.zfar);
+            ? Matrixf::create_orthographic_projection(
+                  static_cast<float>(properties.width), static_cast<float>(properties.aspect),
+                  static_cast<float>(properties.znear), static_cast<float>(properties.zfar))
+            : Matrixf::create_perspective_projection(
+                  static_cast<float>(properties.fov), static_cast<float>(properties.aspect),
+                  static_cast<float>(properties.znear), static_cast<float>(properties.zfar));
     matrices.view_proj     = matrices.view * matrices.projection;
     matrices.view_inv      = inverse(matrices.view);
     matrices.view_proj_inv = inverse(matrices.view_proj);
@@ -35,9 +37,10 @@ Frustum Camera::frustum(const Vector2& p1, const Vector2& p2) const noexcept
     // Constructs a side plane from its coordinates on the near plane (-1 <= x,y <= 1)
     // The @orthogonal_view_dir lies in the plane, orthogonal to the view direction.
     const auto create_side_plane = [&](double x, double y, const Vector3& orthogonal_view_dir) {
-        Vector3 near_position = m_matrices.view_proj_inv.transform_coord(Vector3{x, y, 0.0});
-        Vector3 far_position  = m_matrices.view_proj_inv.transform_coord(Vector3{x, y, 1.0});
-        Vector3 inside_dir    = normalize(cross(far_position - near_position, orthogonal_view_dir));
+        const Vector3 near_position = m_matrices.view_proj_inv.transform_coord(Vector3{x, y, 0.0});
+        const Vector3 far_position  = m_matrices.view_proj_inv.transform_coord(Vector3{x, y, 1.0});
+        const Vector3 inside_dir =
+            normalize(cross(far_position - near_position, orthogonal_view_dir));
         return Plane(near_position, inside_dir);
     };
 

--- a/khepri/src/renderer/diligent/native_window.cpp
+++ b/khepri/src/renderer/diligent/native_window.cpp
@@ -15,7 +15,7 @@
 
 namespace khepri::renderer::diligent {
 
-Diligent::NativeWindow get_native_window(std::any window)
+Diligent::NativeWindow get_native_window(const std::any& window)
 {
     try {
 #ifdef _MSC_VER
@@ -27,9 +27,8 @@ Diligent::NativeWindow get_native_window(std::any window)
         return Diligent::NativeWindow{std::get<1>(native_window), std::get<0>(native_window)};
 #endif
     } catch (const std::bad_any_cast&) {
-        // Fall-through
+        throw ArgumentError();
     }
-    throw ArgumentError();
 }
 
 } // namespace khepri::renderer::diligent

--- a/khepri/src/renderer/diligent/native_window.hpp
+++ b/khepri/src/renderer/diligent/native_window.hpp
@@ -8,6 +8,6 @@ namespace khepri::renderer::diligent {
 // Utility method for extracting a platform-specific native window into a Diligent NativeWindow.
 // This is delegated to its own source file to minimize namespace pollution from various
 // platform-specific headers.
-Diligent::NativeWindow get_native_window(std::any window);
+Diligent::NativeWindow get_native_window(const std::any& window);
 
 } // namespace khepri::renderer::diligent

--- a/khepri/src/renderer/io/texture_tga.cpp
+++ b/khepri/src/renderer/io/texture_tga.cpp
@@ -10,7 +10,7 @@
 namespace khepri::renderer::io {
 namespace {
 
-enum
+enum : std::uint8_t
 {
     targa_image_none         = 0,
     targa_image_color_mapped = 1,
@@ -51,13 +51,13 @@ Header read_header(khepri::io::Stream& stream)
     hdr.image_id_length  = stream.read_uint8();
     hdr.color_map_type   = stream.read_uint8();
     hdr.image_type       = stream.read_uint8();
-    hdr.color_map_start  = stream.read_int16();
-    hdr.color_map_length = stream.read_int16();
+    hdr.color_map_start  = stream.read_uint16();
+    hdr.color_map_length = stream.read_uint16();
     hdr.color_map_bpp    = stream.read_uint8();
-    hdr.image_x          = stream.read_int16();
-    hdr.image_y          = stream.read_int16();
-    hdr.image_width      = stream.read_int16();
-    hdr.image_height     = stream.read_int16();
+    hdr.image_x          = stream.read_uint16();
+    hdr.image_y          = stream.read_uint16();
+    hdr.image_width      = stream.read_uint16();
+    hdr.image_height     = stream.read_uint16();
     hdr.image_bpp        = stream.read_uint8();
     hdr.image_descriptor = stream.read_uint8();
     return hdr;
@@ -68,13 +68,13 @@ void write_header(khepri::io::Stream& stream, const Header& hdr)
     stream.write_uint8(hdr.image_id_length);
     stream.write_uint8(hdr.color_map_type);
     stream.write_uint8(hdr.image_type);
-    stream.write_int16(hdr.color_map_start);
-    stream.write_int16(hdr.color_map_length);
+    stream.write_uint16(hdr.color_map_start);
+    stream.write_uint16(hdr.color_map_length);
     stream.write_uint8(hdr.color_map_bpp);
-    stream.write_int16(hdr.image_x);
-    stream.write_int16(hdr.image_y);
-    stream.write_int16(hdr.image_width);
-    stream.write_int16(hdr.image_height);
+    stream.write_uint16(hdr.image_x);
+    stream.write_uint16(hdr.image_y);
+    stream.write_uint16(hdr.image_width);
+    stream.write_uint16(hdr.image_height);
     stream.write_uint8(hdr.image_bpp);
     stream.write_uint8(hdr.image_descriptor);
 }
@@ -123,8 +123,8 @@ bool is_texture_tga(khepri::io::Stream& stream)
         auto header = read_header(stream);
         return is_valid_header(header);
     } catch (const khepri::io::Error&) {
+        return false;
     }
-    return false;
 }
 
 TextureDesc load_texture_tga(khepri::io::Stream& stream)

--- a/khepri/tests/cubic_spline_test.cpp
+++ b/khepri/tests/cubic_spline_test.cpp
@@ -7,6 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
 
 using khepri::CubicSpline;
@@ -22,7 +23,7 @@ std::ostream& operator<<(std::ostream& os, const CubicSpline& c)
 
 [[nodiscard]] bool near(const Vector3& lhs, const Vector3& rhs, float abs_error)
 {
-    const auto& near = [&](float lhs, float rhs) { return std::abs(lhs - rhs) <= abs_error; };
+    const auto& near = [&](double lhs, double rhs) { return std::abs(lhs - rhs) <= abs_error; };
 
     return near(lhs.x, rhs.x) && near(lhs.y, rhs.y) && near(lhs.z, rhs.z);
 }
@@ -31,177 +32,143 @@ std::ostream& operator<<(std::ostream& os, const CubicSpline& c)
 
 namespace {
 
-auto Near(const Vector3& rhs, float abs_error = 0.001f)
+class ValidSplineMatcher
 {
-    class Vector3NearMatcher
+public:
+    using is_gtest_matcher = void;
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static bool MatchAndExplain(const CubicSpline& spline, std::ostream* os)
     {
-    public:
-        using is_gtest_matcher = void;
-
-        explicit Vector3NearMatcher(const Vector3& rhs, float abs_error)
-            : m_rhs(rhs), m_abs_error(abs_error)
-        {
+        if (!is_spline_interpolating(spline)) {
+            if (os != nullptr) {
+                *os << "spline is not interpolating";
+            }
+            return false;
         }
 
-        bool MatchAndExplain(const Vector3& lhs, std::ostream*) const
-        {
-            return near(lhs, m_rhs, m_abs_error);
+        if (!is_spline_continuous_in_position(spline)) {
+            if (os != nullptr) {
+                *os << "spline is not continuous in position";
+            }
+            return false;
         }
 
-        void DescribeTo(std::ostream* os) const
-        {
-            *os << "is near " << m_rhs;
+        if (!is_spline_continuous_in_tangent(spline)) {
+            if (os != nullptr) {
+                *os << "spline is not continuous in tangent";
+            }
+            return false;
         }
 
-        void DescribeNegationTo(std::ostream* os) const
-        {
-            *os << "isn't near " << m_rhs;
+        if (!is_spline_continuous_in_curvature(spline)) {
+            if (os != nullptr) {
+                *os << "spline is not continuous in curvature";
+            }
+            return false;
         }
+        return true;
+    }
 
-    private:
-        const Vector3 m_rhs;
-        float         m_abs_error;
-    };
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static void DescribeTo(std::ostream* os)
+    {
+        *os << "is a valid spline";
+    }
 
-    return Vector3NearMatcher(rhs, abs_error);
-}
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static void DescribeNegationTo(std::ostream* os)
+    {
+        *os << "is not a valid spline";
+    }
+
+private:
+    static constexpr auto MAX_ERROR = 0.0001;
+
+    static bool is_spline_interpolating(const CubicSpline& spline) noexcept
+    {
+        const auto& points = spline.points();
+        for (std::size_t i = 0; i < points.size(); ++i) {
+            const auto t     = spline.length_at(i) / spline.length();
+            const auto value = spline.sample(t);
+            if (!near(value, points[i], MAX_ERROR)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool is_spline_continuous_in_position(const CubicSpline& spline) noexcept
+    {
+        // Check both sides of the points to see if the positions are really close to each other
+        constexpr auto offset = std::numeric_limits<float>::epsilon();
+        const auto&    points = spline.points();
+        for (std::size_t i = 1; i < points.size() - 1; ++i) {
+            const auto t = spline.length_at(i) / spline.length();
+            ;
+
+            const auto pos_left  = spline.sample(t - offset);
+            const auto pos_right = spline.sample(t + offset);
+            if (!near(pos_left, pos_right, MAX_ERROR)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool is_spline_continuous_in_tangent(const CubicSpline& spline) noexcept
+    {
+        // Check both sides of the points to see if the tangents are really close to each other
+        constexpr auto offset = std::numeric_limits<float>::epsilon();
+        const auto&    points = spline.points();
+        for (std::size_t i = 1; i < points.size() - 1; ++i) {
+            const auto t = spline.length_at(i) / spline.length();
+            ;
+
+            // Note: technically we should divide by @a offset to get the tangent, but since
+            // that's the same on both side of the comparison, we can ignore it.
+            const auto tangent_left  = spline.sample(t) - spline.sample(t - offset);
+            const auto tangent_right = spline.sample(t + offset) - spline.sample(t);
+            if (!near(tangent_left, tangent_right, MAX_ERROR)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool is_spline_continuous_in_curvature(const CubicSpline& spline) noexcept
+    {
+        // Check both sides of the points to see if the curvatures are really close to each
+        // other
+        constexpr auto offset = 0.0001;
+        const auto&    points = spline.points();
+        for (std::size_t i = 1; i < points.size() - 1; ++i) {
+            const auto t = static_cast<double>(i) / static_cast<double>(points.size() - 1);
+
+            // Note: technically we should divide by @a offset to get the tangents, but since
+            // that's the same on both side of the comparison, we can ignore it. Same for
+            // curvature
+            const auto tangent_left_1  = spline.sample(t) - spline.sample(t - offset);
+            const auto tangent_right_1 = spline.sample(t + offset) - spline.sample(t);
+
+            const auto tangent_left_2  = spline.sample(t - offset) - spline.sample(t - 2 * offset);
+            const auto tangent_right_2 = spline.sample(t + 2 * offset) - spline.sample(t + offset);
+
+            const auto curvature_left  = tangent_left_1 - tangent_left_2;
+            const auto curvature_right = tangent_right_2 - tangent_right_1;
+
+            if (!near(curvature_left, curvature_right, MAX_ERROR)) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
 
 // Performs basic checks on the spline such as interpolation of the configured points and C2
 // continuity.
-auto IsValidSpline()
+auto is_valid_spline()
 {
-    static constexpr auto MAX_ERROR = 0.0001f;
-
-    class ValidSplineMatcher
-    {
-    public:
-        using is_gtest_matcher = void;
-
-        bool MatchAndExplain(const CubicSpline& spline, std::ostream* os) const
-        {
-            if (!IsSplineInterpolating(spline)) {
-                if (os != nullptr) {
-                    *os << "spline is not interpolating";
-                }
-                return false;
-            }
-
-            if (!IsSplineContinuousInPosition(spline)) {
-                if (os != nullptr) {
-                    *os << "spline is not continuous in position";
-                }
-                return false;
-            }
-
-            if (!IsSplineContinuousInTangent(spline)) {
-                if (os != nullptr) {
-                    *os << "spline is not continuous in tangent";
-                }
-                return false;
-            }
-
-            if (!IsSplineContinuousInCurvature(spline)) {
-                if (os != nullptr) {
-                    *os << "spline is not continuous in curvature";
-                }
-                return false;
-            }
-            return true;
-        }
-
-        void DescribeTo(std::ostream* os) const
-        {
-            *os << "is a valid spline";
-        }
-
-        void DescribeNegationTo(std::ostream* os) const
-        {
-            *os << "is not a valid spline";
-        }
-
-    private:
-        static bool IsSplineInterpolating(const CubicSpline& spline) noexcept
-        {
-            const auto& points = spline.points();
-            for (std::size_t i = 0; i < points.size(); ++i) {
-                const float t     = spline.length_at(i) / spline.length();
-                const auto  value = spline.sample(t);
-                if (!near(value, points[i], MAX_ERROR)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        static bool IsSplineContinuousInPosition(const CubicSpline& spline) noexcept
-        {
-            // Check both sides of the points to see if the positions are really close to each other
-            constexpr auto offset = std::numeric_limits<float>::epsilon();
-            const auto&    points = spline.points();
-            for (std::size_t i = 1; i < points.size() - 1; ++i) {
-                const auto t = spline.length_at(i) / spline.length();
-                ;
-
-                const auto pos_left  = spline.sample(t - offset);
-                const auto pos_right = spline.sample(t + offset);
-                if (!near(pos_left, pos_right, MAX_ERROR)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        static bool IsSplineContinuousInTangent(const CubicSpline& spline) noexcept
-        {
-            // Check both sides of the points to see if the tangents are really close to each other
-            constexpr auto offset = std::numeric_limits<float>::epsilon();
-            const auto&    points = spline.points();
-            for (std::size_t i = 1; i < points.size() - 1; ++i) {
-                const auto t = spline.length_at(i) / spline.length();
-                ;
-
-                // Note: technically we should divide by @a offset to get the tangent, but since
-                // that's the same on both side of the comparison, we can ignore it.
-                const auto tangent_left  = spline.sample(t) - spline.sample(t - offset);
-                const auto tangent_right = spline.sample(t + offset) - spline.sample(t);
-                if (!near(tangent_left, tangent_right, MAX_ERROR)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        static bool IsSplineContinuousInCurvature(const CubicSpline& spline) noexcept
-        {
-            // Check both sides of the points to see if the curvatures are really close to each
-            // other
-            constexpr auto offset = 0.0001f;
-            const auto&    points = spline.points();
-            for (std::size_t i = 1; i < points.size() - 1; ++i) {
-                const auto t = static_cast<float>(i) / (points.size() - 1);
-
-                // Note: technically we should divide by @a offset to get the tangents, but since
-                // that's the same on both side of the comparison, we can ignore it. Same for
-                // curvature
-                const auto tangent_left_1  = spline.sample(t) - spline.sample(t - offset);
-                const auto tangent_right_1 = spline.sample(t + offset) - spline.sample(t);
-
-                const auto tangent_left_2 =
-                    spline.sample(t - offset) - spline.sample(t - 2 * offset);
-                const auto tangent_right_2 =
-                    spline.sample(t + 2 * offset) - spline.sample(t + offset);
-
-                const auto curvature_left  = tangent_left_1 - tangent_left_2;
-                const auto curvature_right = tangent_right_2 - tangent_right_1;
-
-                if (!near(curvature_left, curvature_right, MAX_ERROR)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-    };
-
     return ValidSplineMatcher{};
 }
 
@@ -214,14 +181,14 @@ TEST(CubicSplineTest, SplineWithZeroPoints_ThrowsArgumentError)
 
 TEST(CubicSplineTest, SplineWithOnePoint_ThrowsArgumentError)
 {
-    static constexpr Vector3 points[] = {{0, 0, 0}};
+    constexpr std::array<Vector3, 1> points{{{0, 0, 0}}};
     EXPECT_THROW(CubicSpline{points}, khepri::ArgumentError);
 }
 
 TEST(CubicSplineTest, LineSpline_HasCorrectLength)
 {
-    static constexpr Vector3 points[] = {{0, 0, 0}, {1, 1, 1}};
-    EXPECT_NEAR(CubicSpline{points}.length(), std::sqrt(3.0), 0.00000001f);
+    constexpr std::array<Vector3, 2> points{{{0, 0, 0}, {1, 1, 1}}};
+    EXPECT_NEAR(CubicSpline{points}.length(), std::sqrt(3.0), 0.00000001);
 }
 
 class ValidCubicSplineTest : public testing::TestWithParam<std::vector<Vector3>>
@@ -230,26 +197,26 @@ class ValidCubicSplineTest : public testing::TestWithParam<std::vector<Vector3>>
 // Test that the spline is valid (interpolating & continuous)
 TEST_P(ValidCubicSplineTest, SplineIsValid)
 {
-    CubicSpline spline(GetParam());
-    EXPECT_THAT(spline, IsValidSpline());
+    const CubicSpline spline(GetParam());
+    EXPECT_THAT(spline, is_valid_spline());
 }
 
 // Test that when sampling at a regular interval along the spline, the distance between returned
 // points is roughly the same.
 TEST_P(ValidCubicSplineTest, SplinePointsAreEquidistant)
 {
-    static constexpr auto MAX_ERROR = 0.0001f;
+    static constexpr auto MAX_ERROR = 0.0001;
 
-    CubicSpline spline(GetParam());
+    const CubicSpline spline(GetParam());
 
     std::vector<Vector3> samples(201);
-    const auto           sample_length = spline.length() / (samples.size() - 1);
+    const auto           sample_length = spline.length() / static_cast<double>(samples.size() - 1);
     for (std::size_t i = 0; i < samples.size(); ++i) {
-        auto t     = static_cast<float>(i) / (samples.size() - 1);
-        samples[i] = spline.sample(t);
+        const auto t = static_cast<double>(i) / static_cast<double>(samples.size() - 1);
+        samples[i]   = spline.sample(t);
     }
 
-    const float distance = khepri::distance(samples[1], samples[0]);
+    const auto distance = khepri::distance(samples[1], samples[0]);
     for (std::size_t i = 1; i < samples.size() - 1; ++i) {
         EXPECT_NEAR(distance, sample_length, MAX_ERROR) << " for point " << i;
     }

--- a/khepri/tests/interpolator_test.cpp
+++ b/khepri/tests/interpolator_test.cpp
@@ -65,7 +65,7 @@ TEST(InterpolatorTest, Interpolator_SampledOutOfBounds_ClampsInput)
 
 TEST(InterpolatorTest, StepInterpolator_InterpolatesInSteps)
 {
-    StepInterpolator interpolator({{0, 5}, {1.5, 3}, {3, 10}});
+    const StepInterpolator interpolator({{0, 5}, {1.5, 3}, {3, 10}});
 
     // It must go through the points
     EXPECT_EQ(interpolator.interpolate(0), 5);
@@ -87,7 +87,7 @@ TEST(InterpolatorTest, LinearInterpolatorFromOnePoint_CreatesHorizontalLine)
 
 TEST(InterpolatorTest, LinearInterpolator_InterpolatesLinearly)
 {
-    LinearInterpolator interpolator({{0, 5}, {1.5, 3}, {3, 11}});
+    const LinearInterpolator interpolator({{0, 5}, {1.5, 3}, {3, 11}});
 
     // It must go through the points
     EXPECT_EQ(interpolator.interpolate(0), 5);
@@ -110,7 +110,7 @@ TEST(InterpolatorTest, CosineInterpolatorFromOnePoint_CreatesHorizontalLine)
 
 TEST(InterpolatorTest, CosineInterpolator_InterpolatesSmoothly)
 {
-    CosineInterpolator interpolator({{0, 5}, {1.5, 3}, {3, 11}});
+    const CosineInterpolator interpolator({{0, 5}, {1.5, 3}, {3, 11}});
 
     // It must go through the points
     EXPECT_EQ(interpolator.interpolate(0), 5);

--- a/khepri/tests/polynomial_test.cpp
+++ b/khepri/tests/polynomial_test.cpp
@@ -11,7 +11,7 @@ using khepri::QuadraticPolynomial;
 
 TEST(PolynomialTest, LinearPolynomial)
 {
-    LinearPolynomial p{1, 2};
+    const LinearPolynomial p{1, 2};
     EXPECT_EQ(p.sample(0), 1);
     EXPECT_EQ(p.sample(1), 3);
     EXPECT_EQ(p.sample(10), 21);
@@ -29,7 +29,7 @@ TEST(PolynomialTest, LinearPolynomial)
 
 TEST(PolynomialTest, QuadraticPolynomial)
 {
-    QuadraticPolynomial p{1, 2, 3};
+    const QuadraticPolynomial p{1, 2, 3};
     EXPECT_EQ(p.sample(0), 1);
     EXPECT_EQ(p.sample(1), 6);
     EXPECT_EQ(p.sample(10), 321);
@@ -52,7 +52,7 @@ TEST(PolynomialTest, QuadraticPolynomial)
 
 TEST(PolynomialTest, CubicPolynomial)
 {
-    CubicPolynomial p{1, 2, 3, 4};
+    const CubicPolynomial p{1, 2, 3, 4};
     EXPECT_EQ(p.sample(0), 1);
     EXPECT_EQ(p.sample(1), 10);
     EXPECT_EQ(p.sample(10), 4321);

--- a/khepri/tools/dae2kmf/src/main.cpp
+++ b/khepri/tools/dae2kmf/src/main.cpp
@@ -44,7 +44,7 @@ void collect_scene_info(const aiScene& scene, const aiNode& node, SceneInfo& inf
     const auto meshes       = gsl::span<aiMesh*>(scene.mMeshes, scene.mNumMeshes);
     const auto mesh_indices = gsl::span<unsigned int>(node.mMeshes, node.mNumMeshes);
 
-    for (unsigned int mesh_index : mesh_indices) {
+    for (const unsigned int mesh_index : mesh_indices) {
         if (mesh_index < scene.mNumMeshes) {
             info.meshes.push_back({meshes[mesh_index], &node});
         }
@@ -116,15 +116,6 @@ khepri::renderer::ModelDesc create_model(const aiScene& scene)
 
     return {std::move(meshes)};
 }
-
-template <class Callable>
-void ignore_exceptions(const Callable& callable)
-{
-    try {
-        callable();
-    } catch (...) {
-    }
-}
 } // namespace
 
 int main(int argc, char* argv[])
@@ -173,10 +164,10 @@ int main(int argc, char* argv[])
         khepri::io::File output(output_path, khepri::io::OpenMode::read_write);
         khepri::renderer::io::write_kmf(model, output);
     } catch (const std::exception& e) {
-        ignore_exceptions([&] { std::cerr << "error: " << e.what() << '\n'; });
+        std::cerr << "error: " << e.what() << '\n';
         return 1;
     } catch (...) {
-        ignore_exceptions([&] { std::cerr << "unknown error\n"; });
+        std::cerr << "unknown error\n";
         return 1;
     }
     return 0;

--- a/openglyph/include/openglyph/assets/asset_cache.hpp
+++ b/openglyph/include/openglyph/assets/asset_cache.hpp
@@ -24,7 +24,9 @@ public:
     AssetCache(AssetLoader& asset_loader, khepri::renderer::Renderer& renderer);
 
     AssetCache(const AssetCache&)            = delete;
+    AssetCache(AssetCache&&)                 = delete;
     AssetCache& operator=(const AssetCache&) = delete;
+    AssetCache& operator=(AssetCache&&)      = delete;
     ~AssetCache();
 
     khepri::renderer::Material* get_material(std::string_view name);

--- a/openglyph/include/openglyph/assets/map.hpp
+++ b/openglyph/include/openglyph/assets/map.hpp
@@ -15,7 +15,7 @@ struct Map
     Header header;
 
     std::vector<Environment> environments;
-    std::uint32_t            active_environment;
+    std::uint32_t            active_environment{0};
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/game/behaviors/render_behavior.hpp
+++ b/openglyph/include/openglyph/game/behaviors/render_behavior.hpp
@@ -16,7 +16,7 @@ public:
 
     explicit RenderBehavior(const renderer::RenderModel& model) : m_model(model) {}
 
-    const auto& model() const noexcept
+    [[nodiscard]] const auto& model() const noexcept
     {
         return m_model;
     }

--- a/openglyph/include/openglyph/game/game_object_type.hpp
+++ b/openglyph/include/openglyph/game/game_object_type.hpp
@@ -21,7 +21,7 @@ struct GameObjectType final
     std::string_view space_model_name;
 
     /// The factor by which the model be scaled
-    double scale_factor;
+    double scale_factor{1.0};
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/game/game_object_type_store.hpp
+++ b/openglyph/include/openglyph/game/game_object_type_store.hpp
@@ -18,7 +18,7 @@ namespace openglyph {
  *
  * The store owns the GameObjectType objects and returns non-owning references.
  */
-class GameObjectTypeStore
+class GameObjectTypeStore final
 {
 public:
     /**
@@ -32,7 +32,9 @@ public:
     GameObjectTypeStore(AssetLoader& asset_loader, std::string_view index_filename);
 
     GameObjectTypeStore(const GameObjectTypeStore&)            = delete;
+    GameObjectTypeStore(GameObjectTypeStore&&)                 = delete;
     GameObjectTypeStore& operator=(const GameObjectTypeStore&) = delete;
+    GameObjectTypeStore& operator=(GameObjectTypeStore&&)      = delete;
     ~GameObjectTypeStore();
 
     /**
@@ -42,7 +44,7 @@ public:
      *
      * @note the name lookup is case insensitive.
      */
-    const GameObjectType* get(std::string_view name) const noexcept
+    [[nodiscard]] const GameObjectType* get(std::string_view name) const noexcept
     {
         const auto it = m_game_object_types.find(name);
         return (it != m_game_object_types.end()) ? it->second : nullptr;
@@ -59,9 +61,9 @@ private:
     // Typically, there are thousands of GameObjectType instances, using a monotonic_buffer_resource
     // to store them significantly speeds up loading and unloading times.
     std::pmr::monotonic_buffer_resource m_memory_resource{std::pmr::get_default_resource()};
-    std::pmr::map<std::string_view, GameObjectType*, khepri::CaseInsensitiveLess>
+    std::pmr::map<std::string_view, const GameObjectType*, khepri::CaseInsensitiveLess>
         m_game_object_types{
-            std::pmr::polymorphic_allocator<std::pair<std::string_view, GameObjectType*>>(
+            std::pmr::polymorphic_allocator<std::pair<std::string_view, const GameObjectType*>>(
                 &m_memory_resource)};
 };
 

--- a/openglyph/include/openglyph/game/scene.hpp
+++ b/openglyph/include/openglyph/game/scene.hpp
@@ -24,8 +24,10 @@ public:
     Scene(AssetCache& asset_cache, const GameObjectTypeStore& game_object_types,
           Environment environment);
 
-    Scene(const Scene&)            = delete;
-    Scene& operator=(const Scene&) = delete;
+    Scene(const Scene&)                = delete;
+    Scene(Scene&&) noexcept            = delete;
+    Scene& operator=(const Scene&)     = delete;
+    Scene& operator=(Scene&&) noexcept = delete;
     ~Scene();
 
     /// Returns the objects in the scene

--- a/openglyph/include/openglyph/game/scene_renderer.hpp
+++ b/openglyph/include/openglyph/game/scene_renderer.hpp
@@ -11,6 +11,12 @@ class SceneRenderer
 {
 public:
     explicit SceneRenderer(khepri::renderer::Renderer& renderer) : m_renderer(renderer) {}
+    ~SceneRenderer() = default;
+
+    SceneRenderer(const SceneRenderer&)                = delete;
+    SceneRenderer(SceneRenderer&&) noexcept            = delete;
+    SceneRenderer& operator=(const SceneRenderer&)     = delete;
+    SceneRenderer& operator=(SceneRenderer&&) noexcept = delete;
 
     void render_scene(const openglyph::Scene& scene, const khepri::renderer::Camera& camera);
 

--- a/openglyph/include/openglyph/io/chunk_reader.hpp
+++ b/openglyph/include/openglyph/io/chunk_reader.hpp
@@ -27,18 +27,24 @@ public:
      * \note The caller must ensure that @a stream is kept alive while this object is alive.
      */
     explicit ChunkReader(khepri::io::Stream& stream);
+    ~ChunkReader() = default;
+
+    ChunkReader(const ChunkReader&)                = delete;
+    ChunkReader(ChunkReader&&) noexcept            = delete;
+    ChunkReader& operator=(const ChunkReader&)     = delete;
+    ChunkReader& operator=(ChunkReader&&) noexcept = delete;
 
     /**
      * Returns the ID of the current chunk
      * \throws khepri::io::error if #has_chunks() is false
      */
-    ChunkId id() const;
+    [[nodiscard]] ChunkId id() const;
 
     /**
      * Does the current chunk contain data or chunks?
      * \throws khepri::io::error if #has_chunks() is false
      */
-    bool has_data() const;
+    [[nodiscard]] bool has_data() const;
 
     /**
      * Reads the current chunk's data.
@@ -51,7 +57,7 @@ public:
     /**
      * Has the end of the current level's chunks been reached?
      */
-    bool has_chunk() const noexcept;
+    [[nodiscard]] bool has_chunk() const noexcept;
 
     /**
      * Advances the reader to the next chunk.
@@ -109,7 +115,7 @@ public:
      * Returns the ID of the current mini-chunk
      * \throws khepri::io::error if #has_chunks() is true
      */
-    ChunkId id() const;
+    [[nodiscard]] ChunkId id() const;
 
     /**
      * Reads the current mini-chunk's data.
@@ -120,7 +126,7 @@ public:
     /**
      * Has the end of the mini-chunks been reached?
      */
-    bool has_chunk() const noexcept;
+    [[nodiscard]] bool has_chunk() const noexcept;
 
     /**
      * Advances the reader to the next mini-chunk.

--- a/openglyph/include/openglyph/parser/parsers.hpp
+++ b/openglyph/include/openglyph/parser/parsers.hpp
@@ -9,6 +9,8 @@
 #include <khepri/math/vector4.hpp>
 #include <khepri/utility/string.hpp>
 
+#include <gsl/gsl-lite.hpp>
+
 #include <charconv>
 #include <cstdint>
 #include <optional>
@@ -17,15 +19,15 @@
 namespace openglyph {
 namespace detail {
 
-bool split(std::string_view str, const char* separators, std::string_view* result,
-           std::size_t count) noexcept;
+bool split(std::string_view str, const char* separators,
+           gsl::span<std::string_view> result) noexcept;
 
 } // namespace detail
 
 template <std::size_t N>
 struct SplitResult
 {
-    std::string_view parts[N];
+    std::array<std::string_view, N> parts;
 };
 
 /**
@@ -35,7 +37,7 @@ template <std::size_t N>
 std::optional<SplitResult<N>> split(std::string_view str, const char* separators) noexcept
 {
     SplitResult<N> result;
-    if (detail::split(str, separators, result.parts, N)) {
+    if (detail::split(str, separators, result.parts)) {
         return result;
     }
     return {};
@@ -72,7 +74,7 @@ struct Parser<T, typename std::enable_if_t<std::is_integral_v<T> || std::is_floa
         if constexpr (std::is_floating_point_v<T>) {
             // Remove any trailing 'f' suffix
             if (!str.empty() && (str.back() == 'f' || str.back() == 'F')) {
-                --end;
+                std::advance(end, -1);
             }
         }
 

--- a/openglyph/include/openglyph/parser/xml_parser.hpp
+++ b/openglyph/include/openglyph/parser/xml_parser.hpp
@@ -3,10 +3,10 @@
 
 #include <khepri/io/stream.hpp>
 
-#include <memory>
 #include <optional>
 #include <rapidxml.hpp>
 #include <string_view>
+#include <vector>
 
 namespace openglyph {
 
@@ -30,13 +30,13 @@ public:
         explicit Attribute(const rapidxml::xml_attribute<Char>* attr) : m_attr(attr) {}
 
         /// The attribute's name
-        std::string_view name() const noexcept
+        [[nodiscard]] std::string_view name() const noexcept
         {
             return {m_attr->name(), m_attr->name_size()};
         }
 
         /// The attribute's value
-        std::string_view value() const noexcept
+        [[nodiscard]] std::string_view value() const noexcept
         {
             return {m_attr->value(), m_attr->value_size()};
         }
@@ -68,7 +68,7 @@ public:
                 return *this;
             }
 
-            Iterator operator++(int) noexcept
+            Iterator operator++(int) & noexcept
             {
                 Iterator retval = *this;
                 ++(*this);
@@ -99,17 +99,17 @@ public:
         {
         }
 
-        Iterator begin() const noexcept
+        [[nodiscard]] Iterator begin() const noexcept
         {
             return Iterator(m_first);
         }
 
-        Iterator end() const noexcept
+        [[nodiscard]] Iterator end() const noexcept
         {
             return Iterator(nullptr);
         }
 
-        bool empty() const noexcept
+        [[nodiscard]] bool empty() const noexcept
         {
             return m_first != nullptr;
         }
@@ -143,7 +143,7 @@ public:
                 return *this;
             }
 
-            Iterator operator++(int) noexcept
+            Iterator operator++(int) & noexcept
             {
                 Iterator retval = *this;
                 ++(*this);
@@ -171,17 +171,17 @@ public:
 
         explicit NodeRange(const rapidxml::xml_node<Char>* first) noexcept : m_first(first) {}
 
-        Iterator begin() const noexcept
+        [[nodiscard]] Iterator begin() const noexcept
         {
             return Iterator(m_first);
         }
 
-        Iterator end() const noexcept
+        [[nodiscard]] Iterator end() const noexcept
         {
             return Iterator(nullptr);
         }
 
-        bool empty() const noexcept
+        [[nodiscard]] bool empty() const noexcept
         {
             return m_first != nullptr;
         }
@@ -204,25 +204,25 @@ public:
         }
 
         /// The node's name
-        std::string_view name() const noexcept
+        [[nodiscard]] std::string_view name() const noexcept
         {
             return {m_node->name(), m_node->name_size()};
         }
 
         /// The node's text content
-        std::string_view value() const noexcept
+        [[nodiscard]] std::string_view value() const noexcept
         {
             return {m_node->value(), m_node->value_size()};
         }
 
         /// The node's attributes
-        AttributeRange attributes() const noexcept
+        [[nodiscard]] AttributeRange attributes() const noexcept
         {
             return AttributeRange(m_node->first_attribute());
         }
 
         /// The node's child nodes
-        NodeRange nodes() const noexcept
+        [[nodiscard]] NodeRange nodes() const noexcept
         {
             return NodeRange(m_node->first_node());
         }
@@ -235,7 +235,8 @@ public:
          *
          * @note the name lookup is case-insensitive.
          */
-        std::optional<std::string_view> attribute(std::string_view name) const noexcept
+        [[nodiscard]] std::optional<std::string_view>
+        attribute(std::string_view name) const noexcept
         {
             const auto* attr = m_node->first_attribute(name.data(), name.size(), false);
             if (attr != nullptr) {
@@ -252,7 +253,7 @@ public:
          *
          * @note the name lookup is case-insensitive.
          */
-        std::optional<Node> child(std::string_view name) const noexcept
+        [[nodiscard]] std::optional<Node> child(std::string_view name) const noexcept
         {
             const auto* xml_node = m_node->first_node(name.data(), name.size(), false);
             if (xml_node != nullptr) {
@@ -279,11 +280,10 @@ public:
     /**
      * @brief Returns the root node of the XML document, if any.
      */
-    std::optional<Node> root() const noexcept;
+    [[nodiscard]] std::optional<Node> root() const noexcept;
 
 private:
-    std::size_t             m_size;
-    std::unique_ptr<Char[]> m_data;
+    std::vector<Char> m_data;
 
     // Note: RapidXML holds a reference to the string contents
     rapidxml::xml_document<Char> m_document;

--- a/openglyph/include/openglyph/renderer/material_store.hpp
+++ b/openglyph/include/openglyph/renderer/material_store.hpp
@@ -16,7 +16,7 @@
 
 namespace openglyph::renderer {
 
-class MaterialStore
+class MaterialStore final
 {
 public:
     template <typename T>
@@ -24,16 +24,17 @@ public:
 
     MaterialStore(khepri::renderer::Renderer&       renderer,
                   Loader<khepri::renderer::Shader>  shader_loader,
-                  Loader<khepri::renderer::Texture> texture_loader)
-        : m_renderer(renderer)
-        , m_shader_loader(std::move(shader_loader))
-        , m_texture_loader(std::move(texture_loader))
-    {
-    }
+                  Loader<khepri::renderer::Texture> texture_loader);
+    ~MaterialStore() = default;
+
+    MaterialStore(const MaterialStore&)                = delete;
+    MaterialStore(MaterialStore&&) noexcept            = delete;
+    MaterialStore& operator=(const MaterialStore&)     = delete;
+    MaterialStore& operator=(MaterialStore&&) noexcept = delete;
 
     void register_materials(gsl::span<const MaterialDesc> material_descs);
 
-    khepri::renderer::Material* get(std::string_view name) const noexcept;
+    [[nodiscard]] khepri::renderer::Material* get(std::string_view name) const noexcept;
 
     auto as_loader()
     {

--- a/openglyph/include/openglyph/renderer/model.hpp
+++ b/openglyph/include/openglyph/renderer/model.hpp
@@ -30,12 +30,12 @@ public:
      */
     struct Vertex
     {
-        khepri::Vector3f  position; ///< Position (in object space)
-        khepri::Vector3f  normal;   ///< Normal vector (in tangent space)
-        khepri::Vector2f  uv[4];    ///< Texture coordinates (in tangent space)
-        khepri::Vector3f  tangent;  ///< Tangent vector (in tangent space)
-        khepri::Vector3f  binormal; ///< Binormal vector (in tangent space)
-        khepri::ColorRGBA color;    ///< Color (in linear color space)
+        khepri::Vector3f                position; ///< Position (in object space)
+        khepri::Vector3f                normal;   ///< Normal vector (in tangent space)
+        std::array<khepri::Vector2f, 4> uv;       ///< Texture coordinates (in tangent space)
+        khepri::Vector3f                tangent;  ///< Tangent vector (in tangent space)
+        khepri::Vector3f                binormal; ///< Binormal vector (in tangent space)
+        khepri::ColorRGBA               color;    ///< Color (in linear color space)
     };
 
     /**
@@ -89,7 +89,7 @@ public:
          * When rendering a model, a version of the mesh with lower detail can be rendered if the
          * model is further away from the camera, thus saving on data that needs to be processed.
          */
-        unsigned int lod;
+        unsigned int lod{0};
 
         /**
          * @brief The mesh's Alt (alternative) level.
@@ -98,7 +98,7 @@ public:
          * for instance, to store "broken" versions of a mesh when the object it belongs to is at
          * low health.
          */
-        unsigned int alt;
+        unsigned int alt{0};
 
         /**
          * @brief Initial visibility of the mesh
@@ -107,7 +107,7 @@ public:
          * default visibility of the mesh. Certain meshes are always invisible (like collision
          * boxes).
          */
-        bool visible;
+        bool visible{true};
 
         /**
          * @brief The materials of the mesh

--- a/openglyph/include/openglyph/renderer/model_creator.hpp
+++ b/openglyph/include/openglyph/renderer/model_creator.hpp
@@ -18,6 +18,12 @@ public:
     ModelCreator(khepri::renderer::Renderer&        renderer,
                  Loader<khepri::renderer::Material> material_loader,
                  Loader<khepri::renderer::Texture>  texture_loader);
+    ~ModelCreator() = default;
+
+    ModelCreator(const ModelCreator&)                = delete;
+    ModelCreator(ModelCreator&&) noexcept            = delete;
+    ModelCreator& operator=(const ModelCreator&)     = delete;
+    ModelCreator& operator=(ModelCreator&&) noexcept = delete;
 
     std::unique_ptr<RenderModel> create_model(const Model& model);
 

--- a/openglyph/include/openglyph/renderer/render_model.hpp
+++ b/openglyph/include/openglyph/renderer/render_model.hpp
@@ -24,7 +24,7 @@ public:
 
     explicit RenderModel(std::vector<Mesh> meshes) : m_meshes(std::move(meshes)) {}
 
-    const auto& meshes() const noexcept
+    [[nodiscard]] const auto& meshes() const noexcept
     {
         return m_meshes;
     }

--- a/openglyph/src/assets/asset_loader.cpp
+++ b/openglyph/src/assets/asset_loader.cpp
@@ -12,8 +12,12 @@ namespace fs = std::filesystem;
 
 namespace openglyph {
 namespace {
-khepri::log::Logger LOG("assets");
-const fs::path      BASE_PATH = "Data";
+constexpr khepri::log::Logger LOG("assets");
+
+fs::path base_path()
+{
+    return "Data";
+}
 } // namespace
 
 AssetLoader::AssetLoader(std::vector<fs::path> data_paths) : m_data_paths(std::move(data_paths)) {}
@@ -21,31 +25,31 @@ AssetLoader::AssetLoader(std::vector<fs::path> data_paths) : m_data_paths(std::m
 std::unique_ptr<khepri::io::Stream> AssetLoader::open_config(std::string_view name)
 {
     const std::array<std::string_view, 1> extensions{"XML"};
-    return open_file(BASE_PATH / "XML", name, extensions);
+    return open_file(base_path() / "XML", name, extensions);
 }
 
 std::unique_ptr<khepri::io::Stream> AssetLoader::open_texture(std::string_view name)
 {
     const std::array<std::string_view, 2> extensions{"DDS", "TGA"};
-    return open_file(BASE_PATH / "Art" / "Textures", name, extensions);
+    return open_file(base_path() / "Art" / "Textures", name, extensions);
 }
 
 std::unique_ptr<khepri::io::Stream> AssetLoader::open_model(std::string_view name)
 {
     const std::array<std::string_view, 1> extensions{"ALO"};
-    return open_file(BASE_PATH / "Art" / "Models", name, extensions);
+    return open_file(base_path() / "Art" / "Models", name, extensions);
 }
 
 std::unique_ptr<khepri::io::Stream> AssetLoader::open_shader(std::string_view name)
 {
     const std::array<std::string_view, 1> extensions{"HLSL"};
-    return open_file(BASE_PATH / "Art" / "Shaders", name, extensions);
+    return open_file(base_path() / "Art" / "Shaders", name, extensions);
 }
 
 std::unique_ptr<khepri::io::Stream> AssetLoader::open_map(std::string_view name)
 {
     const std::array<std::string_view, 1> extensions{"TED"};
-    return open_file(BASE_PATH / "Art" / "Maps", name, extensions);
+    return open_file(base_path() / "Art" / "Maps", name, extensions);
 }
 
 std::unique_ptr<khepri::io::Stream>
@@ -60,11 +64,9 @@ AssetLoader::open_file(const fs::path& base_path, std::string_view name_,
 
     const auto& try_open_file = [this](const fs::path& path) -> std::unique_ptr<khepri::io::File> {
         for (const auto& data_path : m_data_paths) {
-            try {
-                auto file = std::make_unique<khepri::io::File>(data_path / path,
-                                                               khepri::io::OpenMode::read);
-                return file;
-            } catch (khepri::io::Error&) {
+            if (fs::exists(data_path / path)) {
+                return std::make_unique<khepri::io::File>(data_path / path,
+                                                          khepri::io::OpenMode::read);
             }
         }
         return {};

--- a/openglyph/src/assets/io/map.cpp
+++ b/openglyph/src/assets/io/map.cpp
@@ -4,9 +4,11 @@
 #include <openglyph/assets/io/map.hpp>
 #include <openglyph/io/chunk_reader.hpp>
 
+#include <cstdint>
+
 namespace openglyph::io {
 namespace {
-enum MapChunkId
+enum MapChunkId : std::uint16_t
 {
     map_info = 0x00,
     map_data = 0x01,
@@ -29,7 +31,7 @@ void verify(bool condition)
 
 std::string as_string(gsl::span<const uint8_t> data)
 {
-    auto end = std::find(data.begin(), data.end(), 0);
+    const auto* const end = std::find(data.begin(), data.end(), 0);
     return {data.begin(), end};
 }
 
@@ -53,6 +55,8 @@ Map::Header read_map_header(gsl::span<const std::uint8_t> data)
         switch (reader.id()) {
         case 0:
             header.version = as_uint32(reader.read_data());
+            break;
+        default:
             break;
         }
     }
@@ -92,6 +96,8 @@ auto read_map_environment(gsl::span<const std::uint8_t> data)
         case 32:
             environment.skydomes[1].z_angle = khepri::to_radians(as_float(reader.read_data()));
             break;
+        default:
+            break;
         }
     }
     return environment;
@@ -106,6 +112,8 @@ auto read_active_environment(gsl::span<const std::uint8_t> data)
         case 37:
             active_environment = as_uint32(reader.read_data());
             break;
+        default:
+            break;
         }
     }
     return active_environment;
@@ -119,6 +127,8 @@ auto read_map_environments(ChunkReader& reader)
         case MapChunkId::map_data_environment:
             verify(reader.has_data());
             environments.push_back(read_map_environment(reader.read_data()));
+            break;
+        default:
             break;
         }
     }
@@ -139,6 +149,8 @@ auto read_map_environment_set(Map& map, ChunkReader& reader)
             verify(reader.has_data());
             map.active_environment = read_active_environment(reader.read_data());
             break;
+        default:
+            break;
         }
     }
 
@@ -156,6 +168,8 @@ void read_map_data(Map& map, ChunkReader& reader)
             reader.open();
             read_map_environment_set(map, reader);
             reader.close();
+            break;
+        default:
             break;
         }
     }
@@ -180,6 +194,9 @@ openglyph::Map read_map(khepri::io::Stream& stream)
             reader.open();
             read_map_data(map, reader);
             reader.close();
+            break;
+
+        default:
             break;
         }
     }

--- a/openglyph/src/game/scene.cpp
+++ b/openglyph/src/game/scene.cpp
@@ -9,7 +9,7 @@ Scene::Scene(AssetCache& asset_cache, const GameObjectTypeStore& game_object_typ
     : m_game_object_types(game_object_types), m_environment(std::move(environment))
 {
     for (const auto& skydome : m_environment.skydomes) {
-        if (auto* type = m_game_object_types.get(skydome.name)) {
+        if (const auto* type = m_game_object_types.get(skydome.name)) {
             auto object = std::make_shared<khepri::scene::SceneObject>();
             if (const auto* render_model = asset_cache.get_render_model(type->space_model_name)) {
                 auto& behavior = object->create_behavior<openglyph::RenderBehavior>(*render_model);

--- a/openglyph/src/game/scene_renderer.cpp
+++ b/openglyph/src/game/scene_renderer.cpp
@@ -38,9 +38,10 @@ void SceneRenderer::render_scene(const openglyph::Scene&         scene,
     for (const auto& object : scene.objects()) {
         if (const auto* render = object->behavior<RenderBehavior>()) {
             auto* state = object->user_data<RenderState>();
-            if (!state) {
-                object->user_data(
-                    RenderState{render->model(), khepri::Matrixf::create_scaling(render->scale())});
+            if (state == nullptr) {
+                object->user_data(RenderState{
+                    render->model(),
+                    khepri::Matrixf::create_scaling(static_cast<float>(render->scale()))});
                 state = object->user_data<RenderState>();
             }
 

--- a/openglyph/src/io/chunk_reader.cpp
+++ b/openglyph/src/io/chunk_reader.cpp
@@ -20,7 +20,7 @@ ChunkReader::ChunkReader(khepri::io::Stream& stream) : m_stream(stream)
 
 bool ChunkReader::has_chunk() const noexcept
 {
-    return !!m_current;
+    return m_current.has_value();
 }
 
 ChunkId ChunkReader::id() const
@@ -100,11 +100,11 @@ void ChunkReader::read_next()
         throw khepri::io::InvalidFormatError();
     }
 
-    auto id   = m_stream.read_uint32();
-    auto size = m_stream.read_uint32();
-    bool data = ((size & 0x80000000u) == 0);
+    auto       id   = m_stream.read_uint32();
+    auto       size = m_stream.read_uint32();
+    const bool data = ((size & 0x80000000U) == 0);
     pos += 8;
-    size = (size & 0x7fffffffu);
+    size = (size & 0x7fffffffU);
 
     if (pos + size > m_parents.top().end) {
         // The chunk itself doesn't fit
@@ -136,7 +136,7 @@ gsl::span<const std::uint8_t> MinichunkReader::read_data() const
 
 bool MinichunkReader::has_chunk() const noexcept
 {
-    return !!m_current;
+    return m_current.has_value();
 }
 
 void MinichunkReader::next()

--- a/openglyph/src/parser/parsers.cpp
+++ b/openglyph/src/parser/parsers.cpp
@@ -1,19 +1,20 @@
+#include <openglyph/parser/parsers.hpp>
+
 #include <cassert>
 #include <string_view>
 
 namespace openglyph::detail {
 
-bool split(std::string_view str, const char* separators, std::string_view* result,
-           std::size_t count) noexcept
+bool split(std::string_view str, const char* separators,
+           gsl::span<std::string_view> result) noexcept
 {
     assert(separators != nullptr);
-    assert(result != nullptr);
     const char* const space_chars = " \t\r\n\v\f";
 
-    std::size_t i;
+    std::size_t i     = 0;
     auto        start = str.find_first_not_of(space_chars, 0);
 
-    for (i = 0; (i < count) && (start != std::string_view::npos); ++i) {
+    for (; (i < result.size()) && (start != std::string_view::npos); ++i) {
         auto sep       = str.find_first_of(separators, start);
         auto end       = (sep == std::string_view::npos) ? str.size() - 1 : sep - 1;
         auto last_char = str.find_last_not_of(space_chars, end);
@@ -27,7 +28,7 @@ bool split(std::string_view str, const char* separators, std::string_view* resul
         start = (sep != std::string_view::npos) ? str.find_first_not_of(space_chars, sep + 1) : sep;
     }
 
-    return ((i == count) && (start == std::string_view::npos));
+    return ((i == result.size()) && (start == std::string_view::npos));
 }
 
 } // namespace openglyph::detail

--- a/openglyph/src/renderer/io/material.cpp
+++ b/openglyph/src/renderer/io/material.cpp
@@ -6,7 +6,7 @@
 
 namespace openglyph {
 namespace {
-enum class PropertyType
+enum class PropertyType : std::uint8_t
 {
     integer,
     floating,
@@ -166,7 +166,7 @@ std::vector<MaterialDesc> load_materials(khepri::io::Stream& xml_stream)
 {
     std::vector<MaterialDesc> materials;
 
-    openglyph::XmlParser xml(xml_stream);
+    const openglyph::XmlParser xml(xml_stream);
     if (const auto& root = xml.root()) {
         for (const auto& matnode : root->nodes()) {
             try {

--- a/openglyph/src/renderer/material_store.cpp
+++ b/openglyph/src/renderer/material_store.cpp
@@ -12,6 +12,15 @@ template <class... Ts>
 Overloaded(Ts...) -> Overloaded<Ts...>;
 } // namespace
 
+MaterialStore::MaterialStore(khepri::renderer::Renderer&       renderer,
+                             Loader<khepri::renderer::Shader>  shader_loader,
+                             Loader<khepri::renderer::Texture> texture_loader)
+    : m_renderer(renderer)
+    , m_shader_loader(std::move(shader_loader))
+    , m_texture_loader(std::move(texture_loader))
+{
+}
+
 void MaterialStore::register_materials(
     gsl::span<const openglyph::renderer::MaterialDesc> material_descs)
 {

--- a/openglyph/src/renderer/model_creator.cpp
+++ b/openglyph/src/renderer/model_creator.cpp
@@ -32,15 +32,15 @@ std::unique_ptr<RenderModel> ModelCreator::create_model(const Model& model)
             // Set up material parameters
             std::vector<RenderModel::Mesh::Param> params;
             for (const auto& param : material.params) {
-                if (auto val = std::get_if<std::int32_t>(&param.value)) {
+                if (const auto* const val = std::get_if<std::int32_t>(&param.value)) {
                     params.push_back({param.name, *val});
-                } else if (auto val = std::get_if<float>(&param.value)) {
+                } else if (const auto* const val = std::get_if<float>(&param.value)) {
                     params.push_back({param.name, *val});
-                } else if (auto val = std::get_if<khepri::Vector3f>(&param.value)) {
+                } else if (const auto* const val = std::get_if<khepri::Vector3f>(&param.value)) {
                     params.push_back({param.name, *val});
-                } else if (auto val = std::get_if<khepri::Vector4f>(&param.value)) {
+                } else if (const auto* const val = std::get_if<khepri::Vector4f>(&param.value)) {
                     params.push_back({param.name, *val});
-                } else if (auto val = std::get_if<std::string>(&param.value)) {
+                } else if (const auto* const val = std::get_if<std::string>(&param.value)) {
                     if (auto* texture = m_texture_loader(khepri::basename(*val))) {
                         params.push_back({param.name, texture});
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ std::optional<CmdlineArgs> parse_cmdline_arguments(int argc, const char* argv[])
         return args;
     } catch (const cxxopts::OptionException& e) {
         std::cerr << "error: " << e.what() << "\n"
-                  << "Use '--help' for help." << std::endl;
+                  << "Use '--help' for help.\n";
     }
     return {};
 }
@@ -98,11 +98,11 @@ auto create_camera(const khepri::Size& render_size)
         {100, 100, 150},
         {0, 0, 0},
         {0, 0, 1},
-        khepri::to_radians(90.0f),
+        khepri::to_radians(90.0F),
         0,
-        static_cast<float>(render_size.width) / render_size.height,
-        10.0f,
-        100000.0f};
+        static_cast<float>(render_size.width) / static_cast<float>(render_size.height),
+        10.0F,
+        100000.0F};
     return khepri::renderer::Camera{properties};
 }
 
@@ -112,7 +112,7 @@ int main(int argc, const char* argv[])
 {
 #ifndef NDEBUG
     // In debug mode we create a console to log
-    khepri::application::ConsoleLogger console_logger;
+    const khepri::application::ConsoleLogger console_logger;
 #endif
 
     khepri::application::ExceptionHandler exception_handler("main");
@@ -151,9 +151,9 @@ int main(int argc, const char* argv[])
         window.add_size_listener([&] { renderer.render_size(window.render_size()); });
         renderer.render_size(window.render_size());
 
-        openglyph::AssetCache          asset_cache(asset_loader, renderer);
-        openglyph::GameObjectTypeStore game_object_types(asset_loader, "GameObjectFiles.xml");
-        openglyph::Environment         environment{};
+        openglyph::AssetCache                asset_cache(asset_loader, renderer);
+        const openglyph::GameObjectTypeStore game_object_types(asset_loader, "GameObjectFiles.xml");
+        openglyph::Environment               environment{};
 
         if (auto stream = asset_loader.open_map("_SPACE_PLANET_ALDERAAN_01")) {
             const auto map = openglyph::io::read_map(*stream);
@@ -163,20 +163,20 @@ int main(int argc, const char* argv[])
             }
         }
 
-        openglyph::Scene         scene(asset_cache, game_object_types, environment);
+        const openglyph::Scene   scene(asset_cache, game_object_types, environment);
         openglyph::SceneRenderer scene_renderer(renderer);
 
         while (!window.should_close()) {
             khepri::application::Window::poll_events();
             renderer.clear(khepri::renderer::Renderer::clear_all);
 
-            khepri::renderer::Camera camera = create_camera(renderer.render_size());
+            const khepri::renderer::Camera camera = create_camera(renderer.render_size());
             scene_renderer.render_scene(scene, camera);
 
             // Presenting the rendered content has two different approaches, depending on the
-            // rendering system: For OpenGL, the window needs to swap the front and back buffers.
-            // For other systems, the renderer handles the presentation.
-            if (window.use_swap_buffers()) {
+            // rendering system: For OpenGL, the window needs to swap the front and back
+            // buffers. For other systems, the renderer handles the presentation.
+            if (khepri::application::Window::use_swap_buffers()) {
                 window.swap_buffers();
             } else {
                 renderer.present();

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -3,14 +3,14 @@
 namespace openeaw {
 
 namespace {
-const ::khepri::VersionInfo build_version_info{OPENEAW_VERSION_MAJOR, OPENEAW_VERSION_MINOR,
+const ::khepri::VersionInfo BUILD_VERSION_INFO{OPENEAW_VERSION_MAJOR, OPENEAW_VERSION_MINOR,
                                                OPENEAW_VERSION_PATCH, OPENEAW_VERSION_STRING,
                                                OPENEAW_VERSION_CLEAN, OPENEAW_VERSION_COMMIT};
 }
 
 const ::khepri::VersionInfo& version() noexcept
 {
-    return build_version_info;
+    return BUILD_VERSION_INFO;
 }
 
 } // namespace openeaw


### PR DESCRIPTION
This change fixes the majority of clang-tidy warnings, mostly simple, low-hanging fruit. It also updates the `.clang-tidy` configuration to be a little less draconian and more practical.