### PR TITLE
ci: fix PRs from forks

### DIFF
--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -17,4 +17,4 @@ jobs:
         uses:  ytanikin/pr-conventional-commits@1.4.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
-          add_label: 'true'
+          add_label: 'false'  # Adding labels is not allowed from PRs from forks, so don't try to do it.


### PR DESCRIPTION
The "check conventional commits" action tried to add a label to the PR based on the commit type. This is apparently not allowed in PRs coming from forks, so to support those, don't try to add labels.