### PR TITLE
fix: render skydomes in the background

### DIFF
--- a/openglyph/include/openglyph/game/environment.hpp
+++ b/openglyph/include/openglyph/game/environment.hpp
@@ -31,6 +31,8 @@ struct Skydome
  */
 struct Environment
 {
+    static constexpr auto NUM_SKYDOMES = 2;
+
     /**
      * @brief The environment's name.
      */
@@ -43,7 +45,7 @@ struct Environment
      * of some environment. The skydomes should be rendered on top of each other, in the order they
      * are stored. This allows all but the first skydome to be translucent for complex combinations.
      */
-    std::array<Skydome, 2> skydomes;
+    std::array<Skydome, NUM_SKYDOMES> skydomes;
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/game/scene.hpp
+++ b/openglyph/include/openglyph/game/scene.hpp
@@ -30,10 +30,16 @@ public:
     Scene& operator=(Scene&&) noexcept = delete;
     ~Scene();
 
-    /// Returns the objects in the scene
-    [[nodiscard]] const auto& objects() const noexcept
+    /// Returns the skydome scenes
+    [[nodiscard]] const auto& skydome_scenes() const noexcept
     {
-        return m_scene.objects();
+        return m_skydome_scenes;
+    }
+
+    /// Returns the main scene
+    [[nodiscard]] const auto& main_scene() const noexcept
+    {
+        return m_main_scene;
     }
 
     /**
@@ -43,7 +49,7 @@ public:
      */
     void add_object(const std::shared_ptr<khepri::scene::SceneObject>& object)
     {
-        m_scene.add_object(object);
+        m_main_scene.add_object(object);
     }
 
     /**
@@ -53,13 +59,18 @@ public:
      */
     void remove_object(const std::shared_ptr<khepri::scene::SceneObject>& object)
     {
-        m_scene.remove_object(object);
+        m_main_scene.remove_object(object);
     }
 
 private:
     const GameObjectTypeStore& m_game_object_types;
 
-    khepri::scene::Scene m_scene;
+    // The skydome scenes, these are rendererd behind all other objects and are not impacted by
+    // z-near/far limitations of the camera.
+    std::array<khepri::scene::Scene, Environment::NUM_SKYDOMES> m_skydome_scenes;
+
+    // The main scene where all the action happens.
+    khepri::scene::Scene m_main_scene;
 
     Environment m_environment;
 };

--- a/openglyph/include/openglyph/game/scene_renderer.hpp
+++ b/openglyph/include/openglyph/game/scene_renderer.hpp
@@ -21,6 +21,8 @@ public:
     void render_scene(const openglyph::Scene& scene, const khepri::renderer::Camera& camera);
 
 private:
+    void render_scene(const khepri::scene::Scene& scene, const khepri::renderer::Camera& camera);
+
     khepri::renderer::Renderer& m_renderer;
 };
 

--- a/openglyph/src/game/scene.cpp
+++ b/openglyph/src/game/scene.cpp
@@ -8,7 +8,8 @@ Scene::Scene(AssetCache& asset_cache, const GameObjectTypeStore& game_object_typ
              Environment environment)
     : m_game_object_types(game_object_types), m_environment(std::move(environment))
 {
-    for (const auto& skydome : m_environment.skydomes) {
+    for (auto i = 0; i < Environment::NUM_SKYDOMES; ++i) {
+        const auto& skydome = m_environment.skydomes[i];
         if (const auto* type = m_game_object_types.get(skydome.name)) {
             auto object = std::make_shared<khepri::scene::SceneObject>();
             if (const auto* render_model = asset_cache.get_render_model(type->space_model_name)) {
@@ -17,7 +18,7 @@ Scene::Scene(AssetCache& asset_cache, const GameObjectTypeStore& game_object_typ
             }
             object->scale({skydome.scale, skydome.scale, skydome.scale});
             object->rotation(khepri::Quaternion::from_euler(skydome.tilt, 0, skydome.z_angle));
-            add_object(object);
+            m_skydome_scenes[i].add_object(object);
         }
     }
 }

--- a/openglyph/src/game/scene_renderer.cpp
+++ b/openglyph/src/game/scene_renderer.cpp
@@ -33,6 +33,28 @@ public:
 void SceneRenderer::render_scene(const openglyph::Scene&         scene,
                                  const khepri::renderer::Camera& camera)
 {
+    // Create a copy of the camera for rendering skydome scenes. The skydome camera has a larger
+    // znear and zfar to ensure that the skydome is visible from all distances.
+    khepri::renderer::Camera skydome_camera = camera;
+    skydome_camera.znear(10.0f);
+    skydome_camera.zfar(100000.0f);
+
+    for (const auto& skydome_scene : scene.skydome_scenes()) {
+        render_scene(skydome_scene, skydome_camera);
+
+        // Clear the depth and stencil buffers after rendering each skydome scenes so that they can
+        // properly layer without Z-fighting.
+        m_renderer.clear(khepri::renderer::Renderer::clear_depth |
+                         khepri::renderer::Renderer::clear_stencil);
+    }
+
+    // Use the normal, provided camera to render the main scene.
+    render_scene(scene.main_scene(), camera);
+}
+
+void SceneRenderer::render_scene(const khepri::scene::Scene&     scene,
+                                 const khepri::renderer::Camera& camera)
+{
     std::vector<khepri::renderer::MeshInstance> meshes;
 
     for (const auto& object : scene.objects()) {


### PR DESCRIPTION
Skydomes are so large that they fall behind the far Z plane. Render them in a separate background layer with a special camera with modified depth range, and by clearing the depth buffer in-between to avoid interactions between layers.