### PR TITLE
feat: add billboarding

### DIFF
--- a/khepri/include/khepri/math/serialize.hpp
+++ b/khepri/include/khepri/math/serialize.hpp
@@ -78,6 +78,29 @@ struct SerializeTraits<BasicVector4<T>>
     }
 };
 
+/// Specialization of #khepri::io::SerializeTraits for #khepri::ColorRGB
+template <>
+struct SerializeTraits<ColorRGB>
+{
+    /// \see #khepri::io::SerializeTraits::serialize
+    static void serialize(Serializer& s, const ColorRGB& value)
+    {
+        s.write(value.r);
+        s.write(value.g);
+        s.write(value.b);
+    }
+
+    /// \see #khepri::io::SerializeTraits::deserialize
+    static ColorRGB deserialize(Deserializer& d)
+    {
+        ColorRGB c;
+        c.r = d.read<ColorRGBA::ComponentType>();
+        c.g = d.read<ColorRGBA::ComponentType>();
+        c.b = d.read<ColorRGBA::ComponentType>();
+        return c;
+    }
+};
+
 /// Specialization of #khepri::io::SerializeTraits for #khepri::ColorRGBA
 template <>
 struct SerializeTraits<ColorRGBA>

--- a/khepri/include/khepri/math/vector2.hpp
+++ b/khepri/include/khepri/math/vector2.hpp
@@ -224,7 +224,7 @@ public:
         return abs(1.0F - length()) < max_normalized_length;
     }
 
-    /// Constructs a unit vector from an angle with the positive X-axis
+    /// Constructs a unit vector from an angle (in radians) with the positive X-axis
     static BasicVector2 from_angle(ComponentType phi) noexcept
     {
         return BasicVector2(cos(phi), sin(phi));

--- a/khepri/include/khepri/math/vector3.hpp
+++ b/khepri/include/khepri/math/vector3.hpp
@@ -252,7 +252,8 @@ public:
     /// Constructs a unit vector from a tilt (angle above the XY plane) and Z-angle (angle around
     /// Z-axis), both in radians.
     /// \note For Z-angle, 0 radians is the X axis and 1/2 PI radians is the Y axis.
-    [[nodiscard]] static BasicVector3 from_angles(double tilt, double z_angle) noexcept
+    [[nodiscard]] static BasicVector3 from_angles(ComponentType tilt,
+                                                  ComponentType z_angle) noexcept
     {
         const auto r = std::cos(tilt);
         return {r * std::cos(z_angle), r * std::sin(z_angle), std::sin(tilt)};

--- a/openglyph/include/openglyph/game/environment.hpp
+++ b/openglyph/include/openglyph/game/environment.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <khepri/math/color_rgb.hpp>
+#include <khepri/math/vector3.hpp>
+
 #include <array>
 #include <string>
 
@@ -23,6 +26,30 @@ struct Skydome
     double z_angle{0};
 };
 
+struct Light
+{
+    /// Direction the light is pointing **from**
+    khepri::Vector3f from_direction{0, 1, 0};
+
+    /// Diffuse color of the light
+    khepri::ColorRGB color{1, 1, 1};
+
+    /// Specular color of the light
+    khepri::ColorRGB specular_color{0, 0, 0};
+
+    // Intensity of the light
+    float intensity{0.5};
+};
+
+struct Wind
+{
+    /// Direction of the window on the XY plane
+    khepri::Vector2f to_direction;
+
+    // Speed of the wind, in world units per seconds
+    float speed;
+};
+
 /**
  * @brief Environment properties
  *
@@ -32,6 +59,7 @@ struct Skydome
 struct Environment
 {
     static constexpr auto NUM_SKYDOMES = 2;
+    static constexpr auto NUM_LIGHTS   = 3;
 
     /**
      * @brief The environment's name.
@@ -46,6 +74,26 @@ struct Environment
      * are stored. This allows all but the first skydome to be translucent for complex combinations.
      */
     std::array<Skydome, NUM_SKYDOMES> skydomes;
+
+    /**
+     * @brief The lights in the scene.
+     *
+     * A scene typically has multiple light. The first light (i.e. `lights[0]`) is always the 'main'
+     * light that casts shadows, creates specular effects, and so on.
+     */
+    std::array<Light, NUM_LIGHTS> lights;
+
+    /**
+     * @brief Ambient color of the scene. All objects in the scene are always lit by an
+     * omnidirectional light with this color, even if all \a lights are off.
+     */
+    khepri::ColorRGB ambient_color{0.1, 0.1, 0.1};
+
+    /**
+     * @brief Wind information of the scene. Wind is mostly a visual effect that impacts particles,
+     * clouds, and some mesh orientations (e.g. flags).
+     */
+    Wind wind;
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/game/scene.hpp
+++ b/openglyph/include/openglyph/game/scene.hpp
@@ -30,6 +30,12 @@ public:
     Scene& operator=(Scene&&) noexcept = delete;
     ~Scene();
 
+    /// Returns a reference to the environment for this scene
+    [[nodiscard]] const Environment& environment() const noexcept
+    {
+        return m_environment;
+    }
+
     /// Returns the skydome scenes
     [[nodiscard]] const auto& skydome_scenes() const noexcept
     {

--- a/openglyph/include/openglyph/game/scene_renderer.hpp
+++ b/openglyph/include/openglyph/game/scene_renderer.hpp
@@ -21,7 +21,8 @@ public:
     void render_scene(const openglyph::Scene& scene, const khepri::renderer::Camera& camera);
 
 private:
-    void render_scene(const khepri::scene::Scene& scene, const khepri::renderer::Camera& camera);
+    void render_scene(const khepri::scene::Scene& scene, const openglyph::Environment& environment,
+                      const khepri::renderer::Camera& camera);
 
     khepri::renderer::Renderer& m_renderer;
 };

--- a/openglyph/include/openglyph/renderer/billboard.hpp
+++ b/openglyph/include/openglyph/renderer/billboard.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+
+namespace openglyph::renderer {
+
+/**
+ * \brief Billboard modes for bones.
+ *
+ * This enum describes how objects attached to a bone should be rotated to face e.g. the camera, the
+ * main light source, the wind, etc.
+ */
+enum class BillboardMode : std::uint8_t
+{
+    /// No billboard mode, objects are untouched.
+    none,
+
+    /// Rotate object around its local origin so the "front" axis is parallel with the camera's
+    /// direction.
+    parallel,
+
+    /// Rotate object around its local origin so the "front" axis points to the camera.
+    face,
+
+    /// Rotate object around its local Z axis so the "front" axis is parallel with the camera's
+    /// direction.
+    z_view,
+
+    ///< Rotate object around its local Z axis so the "front" axis points in the wind direction.
+    z_wind,
+
+    /// Rotate object around its local Z axis so the "front" axis points to the main light
+    /// source.
+    z_light,
+
+    /// Rotate object around its parent's origin so that the +X axis points to the main light in
+    /// view space, but the object remains in a plane parallel to the camera in world space. Also
+    /// rotates the object as if \a View billboard mode was set.
+    sun_glow,
+
+    /// Rotate object around its parent's origin so that the +X axis points to the main light. Also
+    /// rotates the object as if \a View billboard mode was set.
+    sun,
+};
+
+} // namespace openglyph::renderer

--- a/openglyph/include/openglyph/renderer/model.hpp
+++ b/openglyph/include/openglyph/renderer/model.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "billboard.hpp"
 #include "material_desc.hpp"
 
 #include <khepri/math/color_rgba.hpp>
@@ -21,6 +22,15 @@ class Model
 public:
     /// Type of vertex indices
     using Index = std::uint16_t;
+
+    struct Bone
+    {
+        std::string                  name;
+        std::optional<std::uint32_t> parent_bone_index;
+        bool                         visible;
+        BillboardMode                billboard_mode;
+        khepri::Matrixf              parent_transform; // Relative to the parent bone
+    };
 
     /**
      * The master vertex type.
@@ -81,6 +91,11 @@ public:
         std::string name;
 
         /**
+         * @brief The index of the bone this mesh is attached to, if any.
+         */
+        std::optional<int> bone_index;
+
+        /**
          * @brief The mesh's LoD (level-of-detail) level.
          *
          * Multiple variants of a mesh with more or fewer vertices can be stored in a model. Each
@@ -116,6 +131,11 @@ public:
          */
         std::vector<Material> materials;
     };
+
+    /**
+     * The skeleton of the model.
+     */
+    std::vector<Bone> bones;
 
     /**
      * The meshes in the model

--- a/openglyph/include/openglyph/renderer/render_model.hpp
+++ b/openglyph/include/openglyph/renderer/render_model.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "billboard.hpp"
+
 #include <khepri/renderer/material.hpp>
 #include <khepri/renderer/mesh.hpp>
 #include <khepri/renderer/mesh_instance.hpp>
@@ -17,9 +19,12 @@ public:
 
         std::string                             name;
         std::unique_ptr<khepri::renderer::Mesh> render_mesh;
+        BillboardMode                           billboard_mode;
         khepri::renderer::Material*             material;
         std::vector<Param>                      material_params;
         bool                                    visible;
+        khepri::Matrixf                         root_transform;   // relative to the model's root
+        khepri::Matrixf                         parent_transform; // relative to the mesh's parent
     };
 
     explicit RenderModel(std::vector<Mesh> meshes) : m_meshes(std::move(meshes)) {}

--- a/openglyph/src/game/scene.cpp
+++ b/openglyph/src/game/scene.cpp
@@ -18,7 +18,7 @@ Scene::Scene(AssetCache& asset_cache, const GameObjectTypeStore& game_object_typ
             }
             object->scale({skydome.scale, skydome.scale, skydome.scale});
             object->rotation(khepri::Quaternion::from_euler(skydome.tilt, 0, skydome.z_angle));
-            m_skydome_scenes[i].add_object(object);
+            m_skydome_scenes[i].add_object(std::move(object));
         }
     }
 }


### PR DESCRIPTION
This change adds support for billboarding: during rendering, meshes are rotated (and in some cases, positioned) according to various billboarding options read from the model.

To support this, the skeleton of a model is also read, and the light/wind environment information from the map.

Closes #46