### PR TITLE
refactor: extend math library

### DIFF
--- a/khepri/CMakeLists.txt
+++ b/khepri/CMakeLists.txt
@@ -107,13 +107,15 @@ if (BUILD_TESTING)
     add_executable(${PROJECT_NAME}Tests
         tests/cubic_spline_test.cpp
         tests/interpolator_test.cpp
+        tests/matrix_test.cpp
         tests/polynomial_test.cpp
+        tests/quaternion_test.cpp
     )
 
     target_link_Libraries(${PROJECT_NAME}Tests
         PRIVATE
             ${PROJECT_NAME}
-            GTest::gtest_main
+            GTest::gmock_main
     )
 
     gtest_discover_tests(${PROJECT_NAME}Tests)

--- a/khepri/include/khepri/math/format.hpp
+++ b/khepri/include/khepri/math/format.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "quaternion.hpp"
+#include "vector2.hpp"
+#include "vector3.hpp"
+#include "vector4.hpp"
+
+#include <fmt/format.h>
+
+namespace khepri {
+
+template <typename T>
+struct fmt::formatter<BasicVector2<T>>
+{
+    constexpr auto parse(fmt::format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    auto format(const khepri::BasicVector2<T>& v, format_context& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{{{}, {}}}", v.x, v.y);
+    }
+};
+
+template <typename T>
+struct fmt::formatter<BasicVector3<T>>
+{
+    constexpr auto parse(fmt::format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    auto format(const khepri::BasicVector3<T>& v, format_context& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{{{}, {}, {}}}", v.x, v.y, v.z);
+    }
+};
+
+template <typename T>
+struct fmt::formatter<BasicVector4<T>>
+{
+    constexpr auto parse(fmt::format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    auto format(const khepri::BasicVector4<T>& v, format_context& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{{{}, {}, {}, {}}}", v.x, v.y, v.z, v.w);
+    }
+};
+
+template <typename T>
+struct fmt::formatter<BasicQuaternion<T>>
+{
+    constexpr auto parse(fmt::format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    auto format(const khepri::BasicQuaternion<T>& q, format_context& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{{{}, {}, {}, {}}}", q.x, q.y, q.z, q.w);
+    }
+};
+
+} // namespace khepri

--- a/khepri/include/khepri/math/ios.hpp
+++ b/khepri/include/khepri/math/ios.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "quaternion.hpp"
+#include "vector2.hpp"
+#include "vector3.hpp"
+#include "vector4.hpp"
+
+#include <iostream>
+
+namespace khepri {
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const BasicVector2<T>& v)
+{
+    return os << "{" << v.x << "," << v.y << "}";
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const BasicVector3<T>& v)
+{
+    return os << "{" << v.x << "," << v.y << "," << v.z << "}";
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const BasicVector4<T>& v)
+{
+    return os << "{" << v.x << "," << v.y << "," << v.z << "," << v.w << "}";
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const BasicQuaternion<T>& q)
+{
+    return os << "{" << q.x << "," << q.y << "," << q.z << "," << q.w << "}";
+}
+
+} // namespace khepri

--- a/khepri/include/khepri/math/matrix.hpp
+++ b/khepri/include/khepri/math/matrix.hpp
@@ -13,8 +13,6 @@ namespace khepri {
 template <typename ComponentT>
 class BasicQuaternion;
 
-using Quaternion = BasicQuaternion<double>;
-
 /**
  * \brief 4x4 matrix
  *

--- a/khepri/tests/matchers.hpp
+++ b/khepri/tests/matchers.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+MATCHER_P2(IsNearVector3, v, max_abs_error, "")
+{
+    return std::abs(arg.x - v.x) <= max_abs_error && std::abs(arg.y - v.y) <= max_abs_error &&
+           std::abs(arg.z - v.z) <= max_abs_error;
+}

--- a/khepri/tests/matrix_test.cpp
+++ b/khepri/tests/matrix_test.cpp
@@ -1,0 +1,48 @@
+#include "matchers.hpp"
+
+#include <khepri/math/ios.hpp>
+#include <khepri/math/math.hpp>
+#include <khepri/math/matrix.hpp>
+#include <khepri/math/quaternion.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using khepri::Matrix;
+using khepri::Quaternion;
+using khepri::Vector3;
+
+TEST(MatrixTest, RotationMatrixHandedness)
+{
+    {
+        // Rotate 90 degrees around the X axis.
+        // This assumes a right-handed system, and a right-handed rotation.
+        const auto rot = Matrix::create_rotation(
+            Quaternion::from_axis_angle({1, 0, 0}, khepri::to_radians(90.0)));
+        EXPECT_THAT(Vector3(1, 0, 0) * rot, IsNearVector3(Vector3{1, 0, 0}, 0.001));
+        EXPECT_THAT(Vector3(0, 1, 0) * rot, IsNearVector3(Vector3{0, 0, 1}, 0.001));
+        EXPECT_THAT(Vector3(0, 0, 1) * rot, IsNearVector3(Vector3{0, -1, 0}, 0.001));
+    }
+
+    {
+        // Rotate 90 degrees around the Y axis.
+        // This assumes a right-handed system, and a right-handed rotation.
+        const auto rot = Matrix::create_rotation(
+            Quaternion::from_axis_angle({0, 1, 0}, khepri::to_radians(90.0)));
+        EXPECT_THAT(Vector3(1, 0, 0) * rot, IsNearVector3(Vector3{0, 0, -1}, 0.001));
+        EXPECT_THAT(Vector3(0, 1, 0) * rot, IsNearVector3(Vector3{0, 1, 0}, 0.001));
+        EXPECT_THAT(Vector3(0, 0, 1) * rot, IsNearVector3(Vector3{1, 0, 0}, 0.001));
+    }
+
+    {
+        // Rotate 90 degrees around the Z axis.
+        // This assumes a right-handed system, and a right-handed rotation.
+        const auto rot = Matrix::create_rotation(
+            Quaternion::from_axis_angle({0, 0, 1}, khepri::to_radians(90.0)));
+        EXPECT_THAT(Vector3(1, 0, 0) * rot, IsNearVector3(Vector3{0, 1, 0}, 0.001));
+        EXPECT_THAT(Vector3(0, 1, 0) * rot, IsNearVector3(Vector3{-1, 0, 0}, 0.001));
+        EXPECT_THAT(Vector3(0, 0, 1) * rot, IsNearVector3(Vector3{0, 0, 1}, 0.001));
+    }
+}

--- a/khepri/tests/quaternion_test.cpp
+++ b/khepri/tests/quaternion_test.cpp
@@ -1,0 +1,198 @@
+#include "matchers.hpp"
+
+#include <khepri/math/ios.hpp>
+#include <khepri/math/math.hpp>
+#include <khepri/math/matrix.hpp>
+#include <khepri/math/quaternion.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using khepri::ExtrinsicRotationOrder;
+using khepri::IntrinsicRotationOrder;
+using khepri::Quaternion;
+using khepri::to_radians;
+using khepri::Vector3;
+
+//
+// All tests in this file assume a right-handed system, and a right-handed rotation.
+//
+namespace {
+void CheckCorrectRotation(const Quaternion& q, const Vector3& new_x, const Vector3& new_y,
+                          const Vector3& new_z)
+{
+    EXPECT_THAT(Vector3(1, 0, 0) * q, IsNearVector3(new_x, 0.001));
+    EXPECT_THAT(Vector3(0, 1, 0) * q, IsNearVector3(new_y, 0.001));
+    EXPECT_THAT(Vector3(0, 0, 1) * q, IsNearVector3(new_z, 0.001));
+}
+} // namespace
+
+TEST(QuaternionTest, OneEulerAngle_Intrinstic)
+{
+    // Rotate 90° around X.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), 0, 0, IntrinsicRotationOrder::xyz), {1, 0, 0},
+        {0, 0, 1}, {0, -1, 0});
+
+    // Rotate 90° around Y.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, to_radians(90.0), 0, IntrinsicRotationOrder::xyz), {0, 0, -1},
+        {0, 1, 0}, {1, 0, 0});
+
+    // Rotate 90° around Z.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, 0, to_radians(90.0), IntrinsicRotationOrder::xyz), {0, 1, 0},
+        {-1, 0, 0}, {0, 0, 1});
+}
+
+TEST(QuaternionTest, TwoEulerAngles_Intrinstic)
+{
+    // Rotate 90° around X, then 90° around Y.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), to_radians(90.0), 0, IntrinsicRotationOrder::xyz),
+        {0, 1, 0}, {0, 0, 1}, {1, 0, 0});
+
+    // Rotate 90° around Y, then 90° around X.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), to_radians(90.0), 0, IntrinsicRotationOrder::zyx),
+        {0, 0, -1}, {1, 0, 0}, {0, -1, 0});
+
+    // Rotate 90° around X, then 90° around Z.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), 0, to_radians(90.0), IntrinsicRotationOrder::xyz),
+        {0, 0, 1}, {-1, 0, 0}, {0, -1, 0});
+
+    // Rotate 90° around Z, then 90° around X.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), 0, to_radians(90.0), IntrinsicRotationOrder::zyx),
+        {0, 1, 0}, {0, 0, 1}, {1, 0, 0});
+
+    // Rotate 90° around Y, then 90° around Z.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, to_radians(90.0), to_radians(90.0), IntrinsicRotationOrder::xyz),
+        {0, 1, 0}, {0, 0, 1}, {1, 0, 0});
+
+    // Rotate 90° around Z, then 90° around Y.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, to_radians(90.0), to_radians(90.0), IntrinsicRotationOrder::zyx),
+        {0, 0, -1}, {-1, 0, 0}, {0, 1, 0});
+}
+
+TEST(QuaternionTest, ThreeEulerAngles_Intrinstic)
+{
+    // Rotate 90° around X, then 90° around Y, then 90° around Z.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), IntrinsicRotationOrder::xyz),
+                         {0, 0, 1}, {0, -1, 0}, {1, 0, 0});
+
+    // Rotate 90° around X, then 90° around Z, then 90° around Y.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), IntrinsicRotationOrder::xzy),
+                         {0, 1, 0}, {-1, 0, 0}, {0, 0, 1});
+
+    // Rotate 90° around Y, then 90° around X, then 90° around Z.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), IntrinsicRotationOrder::yxz),
+                         {1, 0, 0}, {0, 0, 1}, {0, -1, 0});
+
+    // Rotate 90° around Y, then 90° around Z, then 90° around X.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), IntrinsicRotationOrder::yzx),
+                         {0, 1, 0}, {1, 0, 0}, {0, 0, -1});
+
+    // Rotate 90° around Z, then 90° around X, then 90° around Y.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), IntrinsicRotationOrder::zxy),
+                         {-1, 0, 0}, {0, 0, 1}, {0, 1, 0});
+
+    // Rotate 90° around Z, then 90° around Y, then 90° around X.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), IntrinsicRotationOrder::zyx),
+                         {0, 0, -1}, {0, 1, 0}, {1, 0, 0});
+}
+
+TEST(QuaternionTest, OneEulerAngle_Extrinstic)
+{
+    // Rotate 90° around X.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), 0, 0, ExtrinsicRotationOrder::xyz), {1, 0, 0},
+        {0, 0, 1}, {0, -1, 0});
+
+    // Rotate 90° around Y.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, to_radians(90.0), 0, ExtrinsicRotationOrder::xyz), {0, 0, -1},
+        {0, 1, 0}, {1, 0, 0});
+
+    // Rotate 90° around Z.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, 0, to_radians(90.0), ExtrinsicRotationOrder::xyz), {0, 1, 0},
+        {-1, 0, 0}, {0, 0, 1});
+}
+
+TEST(QuaternionTest, TwoEulerAngles_Extrinstic)
+{
+    // Rotate 90° around X, then 90° around Y.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), to_radians(90.0), 0, ExtrinsicRotationOrder::xyz),
+        {0, 0, -1}, {1, 0, 0}, {0, -1, 0});
+
+    // Rotate 90° around Y, then 90° around X.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), to_radians(90.0), 0, ExtrinsicRotationOrder::zyx),
+        {0, 1, 0}, {0, 0, 1}, {1, 0, 0});
+
+    // Rotate 90° around X, then 90° around Z.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), 0, to_radians(90.0), ExtrinsicRotationOrder::xyz),
+        {0, 1, 0}, {0, 0, 1}, {1, 0, 0});
+
+    // Rotate 90° around Z, then 90° around X.
+    CheckCorrectRotation(
+        Quaternion::from_euler(to_radians(90.0), 0, to_radians(90.0), ExtrinsicRotationOrder::zyx),
+        {0, 0, 1}, {-1, 0, 0}, {0, -1, 0});
+
+    // Rotate 90° around Y, then 90° around Z.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, to_radians(90.0), to_radians(90.0), ExtrinsicRotationOrder::xyz),
+        {0, 0, -1}, {-1, 0, 0}, {0, 1, 0});
+
+    // Rotate 90° around Z, then 90° around Y.
+    CheckCorrectRotation(
+        Quaternion::from_euler(0, to_radians(90.0), to_radians(90.0), ExtrinsicRotationOrder::zyx),
+        {0, 1, 0}, {0, 0, 1}, {1, 0, 0});
+}
+
+TEST(QuaternionTest, ThreeEulerAngles_Extrinstic)
+{
+    // Rotate 90° around X, then 90° around Y, then 90° around Z.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), ExtrinsicRotationOrder::xyz),
+                         {0, 0, -1}, {0, 1, 0}, {1, 0, 0});
+
+    // Rotate 90° around X, then 90° around Z, then 90° around Y.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), ExtrinsicRotationOrder::xzy),
+                         {0, 1, 0}, {1, 0, 0}, {0, 0, -1});
+
+    // Rotate 90° around Y, then 90° around X, then 90° around Z.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), ExtrinsicRotationOrder::yxz),
+                         {-1, 0, 0}, {0, 0, 1}, {0, 1, 0});
+
+    // Rotate 90° around Y, then 90° around Z, then 90° around X.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), ExtrinsicRotationOrder::yzx),
+                         {0, 1, 0}, {-1, 0, 0}, {0, 0, 1});
+
+    // Rotate 90° around Z, then 90° around X, then 90° around Y.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), ExtrinsicRotationOrder::zxy),
+                         {1, 0, 0}, {0, 0, 1}, {0, -1, 0});
+
+    // Rotate 90° around Z, then 90° around Y, then 90° around X.
+    CheckCorrectRotation(Quaternion::from_euler(to_radians(90.0), to_radians(90.0),
+                                                to_radians(90.0), ExtrinsicRotationOrder::zyx),
+                         {0, 0, 1}, {0, -1, 0}, {1, 0, 0});
+}

--- a/openglyph/src/game/scene.cpp
+++ b/openglyph/src/game/scene.cpp
@@ -17,7 +17,8 @@ Scene::Scene(AssetCache& asset_cache, const GameObjectTypeStore& game_object_typ
                 behavior.scale(type->scale_factor);
             }
             object->scale({skydome.scale, skydome.scale, skydome.scale});
-            object->rotation(khepri::Quaternion::from_euler(skydome.tilt, 0, skydome.z_angle));
+            object->rotation(khepri::Quaternion::from_euler(skydome.tilt, 0, skydome.z_angle,
+                                                            khepri::ExtrinsicRotationOrder::zyx));
             m_skydome_scenes[i].add_object(std::move(object));
         }
     }


### PR DESCRIPTION
Khepri's math library is extended with a richer Quaternion rotation (intrinsic vs extrinsic Euler angles, with configurable order), some tests, and a couple of formatting methods for `std::ostream` and `fmt`.