### PR TITLE
feat: respect In_Background property of objects

### DIFF
--- a/openglyph/include/openglyph/game/behaviors/render_behavior.hpp
+++ b/openglyph/include/openglyph/game/behaviors/render_behavior.hpp
@@ -9,9 +9,12 @@ namespace openglyph {
 class RenderBehavior : public khepri::scene::Behavior
 {
 public:
-    struct Type
+    enum class RenderLayer
     {
-        std::string model_name;
+        // Background layer
+        background,
+        // Foreground layer
+        foreground
     };
 
     explicit RenderBehavior(const renderer::RenderModel& model) : m_model(model) {}
@@ -26,14 +29,25 @@ public:
         return m_scale;
     }
 
+    [[nodiscard]] RenderLayer render_layer() const noexcept
+    {
+        return m_render_layer;
+    }
+
     void scale(double scale) noexcept
     {
         m_scale = scale;
     }
 
+    void render_layer(RenderLayer render_layer) noexcept
+    {
+        m_render_layer = render_layer;
+    }
+
 private:
     const renderer::RenderModel& m_model;
     double                       m_scale{1.0};
+    RenderLayer                  m_render_layer{RenderLayer::foreground};
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/game/game_object_type.hpp
+++ b/openglyph/include/openglyph/game/game_object_type.hpp
@@ -22,6 +22,9 @@ struct GameObjectType final
 
     /// The factor by which the model be scaled
     double scale_factor{1.0};
+
+    /// Should this object be rendered in the background layer?
+    bool is_in_background;
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/game/scene.hpp
+++ b/openglyph/include/openglyph/game/scene.hpp
@@ -36,16 +36,16 @@ public:
         return m_environment;
     }
 
-    /// Returns the skydome scenes
-    [[nodiscard]] const auto& skydome_scenes() const noexcept
+    /// Returns the background scene
+    [[nodiscard]] const auto& background_scene() const noexcept
     {
-        return m_skydome_scenes;
+        return m_background_scene;
     }
 
     /// Returns the main scene
-    [[nodiscard]] const auto& main_scene() const noexcept
+    [[nodiscard]] const auto& foreground_scene() const noexcept
     {
-        return m_main_scene;
+        return m_foreground_scene;
     }
 
     /**
@@ -53,30 +53,27 @@ public:
      *
      * Does nothing if the object is already added.
      */
-    void add_object(const std::shared_ptr<khepri::scene::SceneObject>& object)
-    {
-        m_main_scene.add_object(object);
-    }
+    void add_object(const std::shared_ptr<khepri::scene::SceneObject>& object);
 
     /**
      * Removes an object from the scene.
      *
      * Does nothing if the object is not in the scene.
      */
-    void remove_object(const std::shared_ptr<khepri::scene::SceneObject>& object)
-    {
-        m_main_scene.remove_object(object);
-    }
+    void remove_object(const std::shared_ptr<khepri::scene::SceneObject>& object);
 
 private:
+    // Returns a reference to the scene the object should be placed into
+    khepri::scene::Scene& target_scene(const khepri::scene::SceneObject& object);
+
     const GameObjectTypeStore& m_game_object_types;
 
-    // The skydome scenes, these are rendererd behind all other objects and are not impacted by
-    // z-near/far limitations of the camera.
-    std::array<khepri::scene::Scene, Environment::NUM_SKYDOMES> m_skydome_scenes;
+    // Special "background" scene that's rendered behind the foreground scene with special depth
+    // range and no fog. Useful for objects that should always appear in the background.
+    khepri::scene::Scene m_background_scene;
 
-    // The main scene where all the action happens.
-    khepri::scene::Scene m_main_scene;
+    // The main foreground scene where all the action happens.
+    khepri::scene::Scene m_foreground_scene;
 
     Environment m_environment;
 };

--- a/openglyph/src/game/game_object_type_store.cpp
+++ b/openglyph/src/game/game_object_type_store.cpp
@@ -34,6 +34,7 @@ GameObjectType* GameObjectTypeStore::read_game_object_type(const XmlParser::Node
     type->name             = copy_string(require_attribute(node, "Name"));
     type->space_model_name = copy_string(optional_child(node, "Space_Model_Name", ""sv));
     type->scale_factor     = optional_child(node, "Scale_Factor", 1.0);
+    type->is_in_background = optional_child(node, "In_Background", false);
     return type;
 }
 

--- a/openglyph/src/game/scene_renderer.cpp
+++ b/openglyph/src/game/scene_renderer.cpp
@@ -176,23 +176,21 @@ void apply_billboard(khepri::Matrixf& transform, const renderer::RenderModel::Me
 void SceneRenderer::render_scene(const openglyph::Scene&         scene,
                                  const khepri::renderer::Camera& camera)
 {
-    // Create a copy of the camera for rendering skydome scenes. The skydome camera has a larger
-    // znear and zfar to ensure that the skydome is visible from all distances.
-    khepri::renderer::Camera skydome_camera = camera;
-    skydome_camera.znear(10.0f);
-    skydome_camera.zfar(100000.0f);
+    // Create a copy of the camera for rendering the background scene. This camera has a larger
+    // znear and zfar to ensure that the background objects are visible from all distances.
+    khepri::renderer::Camera background_camera = camera;
+    background_camera.znear(10.0f);
+    background_camera.zfar(100000.0f);
 
-    for (const auto& skydome_scene : scene.skydome_scenes()) {
-        render_scene(skydome_scene, scene.environment(), skydome_camera);
+    render_scene(scene.background_scene(), scene.environment(), background_camera);
 
-        // Clear the depth and stencil buffers after rendering each skydome scenes so that they can
-        // properly layer without Z-fighting.
-        m_renderer.clear(khepri::renderer::Renderer::clear_depth |
-                         khepri::renderer::Renderer::clear_stencil);
-    }
+    // Clear the depth and stencil buffers after rendering the background scene so that they can
+    // properly layer without Z-fighting.
+    m_renderer.clear(khepri::renderer::Renderer::clear_depth |
+                     khepri::renderer::Renderer::clear_stencil);
 
     // Use the normal, provided camera to render the main scene.
-    render_scene(scene.main_scene(), scene.environment(), camera);
+    render_scene(scene.foreground_scene(), scene.environment(), camera);
 }
 
 void SceneRenderer::render_scene(const khepri::scene::Scene&     scene,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,9 @@ CreateScene(std::string_view map_name, openglyph::AssetLoader& asset_loader,
                     auto& behavior =
                         object->create_behavior<openglyph::RenderBehavior>(*render_model);
                     behavior.scale(type->scale_factor);
+                    if (type->is_in_background) {
+                        behavior.render_layer(openglyph::RenderBehavior::RenderLayer::background);
+                    }
                 }
                 object->rotation(obj.facing);
                 object->position(obj.position);


### PR DESCRIPTION
Previously only the map's skydomes were hardcoded to be put in the background scene, but the map can contain additional objects which should go into the background (e.g. the planet backdrop), as indicated by their In_Background property.