### PR TITLE
feat: add render pipelines

### DIFF
--- a/data-extra/Data/XML/Materials.xml
+++ b/data-extra/Data/XML/Materials.xml
@@ -18,7 +18,7 @@
     </Material>
     -->
 
-    <Material Name="MeshBumpColorize">
+    <Material Name="MeshBumpColorize" Type="Opaque">
         <Shader>MeshBumpColorize</Shader>
         <Param Name="Colorization" Type="float3">1, 1, 1</Param>
         <Param Name="Diffuse" Type="float3">1, 1, 1</Param>
@@ -26,7 +26,7 @@
         <Param Name="NormalTexture" Type="texture"></Param>
     </Material>
 
-    <Material Name="MeshGloss" AlphaBlend="blend_src" DepthFunc="less_equal">
+    <Material Name="MeshGloss" Type="Opaque">
         <Shader>MeshGloss</Shader>
         <Param Name="Emissive" Type="float3">0, 0, 0</Param>
         <Param Name="Diffuse" Type="float3">1, 1, 1</Param>
@@ -35,14 +35,14 @@
         <Param Name="BaseTexture" Type="texture"></Param>
     </Material>
 
-    <Material Name="MeshAdditive" AlphaBlend="additive" DepthWriteEnable="false" DepthFunc="less_equal">
+    <Material Name="MeshAdditive" Type="Transparent">
         <Shader>MeshAdditive</Shader>
         <Param Name="Color" Type="float3">1, 0, 1</Param>
         <Param Name="UVScrollRate" Type="float2">0, 0</Param>
         <Param Name="BaseTexture" Type="texture"></Param>
     </Material>
 
-    <Material Name="MeshAdditiveVColor" AlphaBlend="additive" DepthWriteEnable="false" DepthFunc="less_equal">
+    <Material Name="MeshAdditiveVColor" Type="Transparent">
         <Shader>MeshAdditiveVColor</Shader>
         <Param Name="UVScrollRate" Type="float2">0, 0</Param>
         <Param Name="BaseTexture" Type="texture"></Param>

--- a/data-extra/Data/XML/RenderPipelines.xml
+++ b/data-extra/Data/XML/RenderPipelines.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<RenderPipelines>
+    <RenderPipeline Name="Default">
+        <!-- Render phase for all solid, non-transparent objects. -->
+        <RenderPass>
+            <Material_Type>Opaque</Material_Type>
+            <!-- Sort front-to-back to minimize overdraw -->
+            <Depth_Sort>front_to_back</Depth_Sort>
+            <AlphaBlend>blend_src</AlphaBlend>
+            <DepthFunc>less_equal</DepthFunc>
+        </RenderPass>
+
+        <!-- Render phase for all transparent objects. This is rendered after the solids to allow alpha-blending effects to work -->
+        <RenderPass>
+            <Material_Type>Transparent</Material_Type>
+            <!-- Sort back-to-front to ensure alpha blending works correctly -->
+            <Depth_Sort>back_to_front</Depth_Sort>
+            <AlphaBlend>additive</AlphaBlend>
+            <DepthFunc>less_equal</DepthFunc>
+            <DepthWriteEnable>false</DepthWriteEnable>
+        </RenderPass>
+    </RenderPipeline>
+</RenderPipelines>

--- a/khepri/include/khepri/renderer/diligent/renderer.hpp
+++ b/khepri/include/khepri/renderer/diligent/renderer.hpp
@@ -57,6 +57,10 @@ public:
     /// \see #khepri::renderer::Renderer::create_mesh
     std::unique_ptr<Mesh> create_mesh(const MeshDesc& mesh_desc) override;
 
+    /// \see #khepri::renderer::Renderer::create_render_pipeline
+    std::unique_ptr<RenderPipeline>
+    create_render_pipeline(const RenderPipelineDesc& render_pipeline_desc) override;
+
     /// \see #khepri::renderer::Renderer::clear
     void clear(ClearFlags flags) override;
 
@@ -64,11 +68,12 @@ public:
     void present() override;
 
     /// \see #khepri::renderer::Renderer::render_meshes
-    void render_meshes(gsl::span<const MeshInstance> meshes, const Camera& camera) override;
+    void render_meshes(RenderPipeline& render_pipeline, gsl::span<const MeshInstance> meshes,
+                       const Camera& camera) override;
 
     /// \see #khepri::renderer::Renderer::render_sprites
-    void render_sprites(gsl::span<const Sprite> sprites, Material& material,
-                        gsl::span<const Material::Param> params) override;
+    void render_sprites(RenderPipeline& render_pipeline, gsl::span<const Sprite> sprites,
+                        Material& material, gsl::span<const Material::Param> params) override;
 
 private:
     class Impl;

--- a/khepri/include/khepri/renderer/material.hpp
+++ b/khepri/include/khepri/renderer/material.hpp
@@ -32,10 +32,11 @@ public:
     Material()          = default;
     virtual ~Material() = default;
 
-    Material(const Material&)            = delete;
-    Material(Material&&)                 = delete;
-    Material& operator=(const Material&) = delete;
-    Material& operator=(Material&&)      = delete;
+protected:
+    Material(const Material&)            = default;
+    Material(Material&&)                 = default;
+    Material& operator=(const Material&) = default;
+    Material& operator=(Material&&)      = default;
 };
 
 } // namespace khepri::renderer

--- a/khepri/include/khepri/renderer/material_desc.hpp
+++ b/khepri/include/khepri/renderer/material_desc.hpp
@@ -30,40 +30,6 @@ namespace khepri::renderer {
  */
 struct MaterialDesc
 {
-    /// The type of face culling
-    enum class CullMode : std::uint8_t
-    {
-        none,
-        back,
-        front,
-    };
-
-    /// The type of alpha blending
-    enum class AlphaBlendMode : std::uint8_t
-    {
-        /// Do not alpha blend.
-        none,
-
-        /// Source and destination are blended according to source alpha.
-        blend_src,
-
-        /// Source is added on top of destination.
-        additive,
-    };
-
-    /// Comparison function for depth or stencil buffer operations
-    enum class ComparisonFunc : std::uint8_t
-    {
-        never,
-        less,
-        equal,
-        less_equal,
-        greater,
-        not_equal,
-        greater_equal,
-        always,
-    };
-
     /// Value of a material shader property
     using PropertyValue =
         std::variant<std::int32_t, float, Vector2f, Vector3f, Vector4f, Matrixf, Texture*>;
@@ -79,24 +45,9 @@ struct MaterialDesc
         PropertyValue default_value;
     };
 
-    struct DepthBufferDesc
-    {
-        /// Depth test comparison function, if any.
-        /// Set to \a std::nullopt to disable depth testing.
-        ComparisonFunc comparison_func{ComparisonFunc::less};
-
-        /// Enable depth-buffer writing
-        bool write_enable{true};
-    };
-
-    /// Face culling mode of this material
-    CullMode cull_mode{CullMode::none};
-
-    /// Type of alpha blending to use when rendering with this material
-    AlphaBlendMode alpha_blend_mode{AlphaBlendMode::none};
-
-    /// Depth-buffer settings to use when rendering this material
-    std::optional<DepthBufferDesc> depth_buffer;
+    /// The type of the material. This is only used to allow render passes in the render pipeline to
+    /// render certain materials. See #khepri::renderer::RenderPassDesc.
+    std::string type;
 
     /// Shader of this material
     Shader* shader{nullptr};

--- a/khepri/include/khepri/renderer/mesh.hpp
+++ b/khepri/include/khepri/renderer/mesh.hpp
@@ -18,10 +18,11 @@ public:
     Mesh()          = default;
     virtual ~Mesh() = default;
 
-    Mesh(const Mesh&)            = delete;
-    Mesh(Mesh&&)                 = delete;
-    Mesh& operator=(const Mesh&) = delete;
-    Mesh& operator=(Mesh&&)      = delete;
+protected:
+    Mesh(const Mesh&)            = default;
+    Mesh(Mesh&&)                 = default;
+    Mesh& operator=(const Mesh&) = default;
+    Mesh& operator=(Mesh&&)      = default;
 };
 
 } // namespace khepri::renderer

--- a/khepri/include/khepri/renderer/render_pipeline.hpp
+++ b/khepri/include/khepri/renderer/render_pipeline.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "material.hpp"
+#include "material_desc.hpp"
+
+#include <memory>
+
+namespace khepri::renderer {
+
+/**
+ * \brief A render pipeline.
+ *
+ * A render pipeline is a collection of steps (render passes) that collectively render meshes to the
+ * screen. Render pipelines are created by a #khepri::renderer::Renderer.
+ *
+ * \see #khepri::renderer::Renderer::create_render_pipeline.
+ */
+class RenderPipeline
+{
+public:
+    RenderPipeline()          = default;
+    virtual ~RenderPipeline() = default;
+
+protected:
+    RenderPipeline(const RenderPipeline&)            = default;
+    RenderPipeline(RenderPipeline&&)                 = default;
+    RenderPipeline& operator=(const RenderPipeline&) = default;
+    RenderPipeline& operator=(RenderPipeline&&)      = default;
+};
+
+} // namespace khepri::renderer

--- a/khepri/include/khepri/renderer/render_pipeline_desc.hpp
+++ b/khepri/include/khepri/renderer/render_pipeline_desc.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace khepri::renderer {
+
+/**
+ * Description of a render pass in a pipeline.
+ *
+ * A render pass renders meshes in a certain way.
+ */
+struct RenderPassDesc
+{
+    /// How to sort objects by depth during this render pass
+    enum class DepthSorting : std::uint8_t
+    {
+        /// Objects are rendered in arbitrary order.
+        none,
+
+        /// Objects are rendered front-to-back, i.e. those closer to the camera are rendered first.
+        front_to_back,
+
+        /// Objects are rendered back-to-front, i.e. those closer to the camera are rendered last.
+        back_to_front,
+    };
+
+    /// The type of face culling
+    enum class CullMode : std::uint8_t
+    {
+        none,
+        back,
+        front,
+    };
+
+    /// Comparison function for depth or stencil buffer operations
+    enum class ComparisonFunc : std::uint8_t
+    {
+        never,
+        less,
+        equal,
+        less_equal,
+        greater,
+        not_equal,
+        greater_equal,
+        always,
+    };
+
+    /// The type of alpha blending
+    enum class AlphaBlendMode : std::uint8_t
+    {
+        /// Do not alpha blend.
+        none,
+
+        /// Source and destination are blended according to source alpha.
+        blend_src,
+
+        /// Source is added on top of destination.
+        additive,
+    };
+
+    struct DepthBufferDesc
+    {
+        /// Depth test comparison function, if any.
+        /// Set to \a std::nullopt to disable depth testing.
+        ComparisonFunc comparison_func{ComparisonFunc::less};
+
+        /// Enable depth-buffer writing
+        bool write_enable{true};
+    };
+
+    /// The type of materials to render in this pass. Must match
+    /// #khepri::renderer::MaterialDesc::type.
+    std::string material_type;
+
+    /// Face culling mode of this render pass.
+    CullMode cull_mode{CullMode::none};
+
+    /// How to depth-sort the objects assigned to this render pass.
+    DepthSorting depth_sorting{DepthSorting::none};
+
+    /// Type of alpha blending to use for this render pass.
+    AlphaBlendMode alpha_blend_mode{AlphaBlendMode::none};
+
+    /// Depth-buffer settings to use for this render pass.
+    std::optional<DepthBufferDesc> depth_buffer;
+};
+
+/**
+ * \brief Description of a render pipeline
+ *
+ * A render pipeline describes how to render the meshes assigned for rendering. It defines
+ * properties like post-processing and other complex effects. A pipeline is split into render passes
+ * that render meshes in a certain way. Each pass has its own properties. A pass can render only
+ * a selection of meshes based on the mesh's material.
+ */
+struct RenderPipelineDesc
+{
+    /// Name of the pipeline; used for debugging purposes
+    std::string name;
+
+    /// Collection of render passes; these are rendered in order.
+    std::vector<RenderPassDesc> render_passes;
+};
+
+} // namespace khepri::renderer

--- a/khepri/include/khepri/renderer/renderer.hpp
+++ b/khepri/include/khepri/renderer/renderer.hpp
@@ -6,6 +6,8 @@
 #include "mesh.hpp"
 #include "mesh_desc.hpp"
 #include "mesh_instance.hpp"
+#include "render_pipeline.hpp"
+#include "render_pipeline_desc.hpp"
 #include "shader.hpp"
 #include "shader_desc.hpp"
 #include "sprite.hpp"
@@ -102,7 +104,7 @@ public:
     virtual std::unique_ptr<Texture> create_texture(const TextureDesc& texture_desc) = 0;
 
     /**
-     * \brief Creates a mesh from a mesh descrpition.
+     * \brief Creates a mesh from a mesh description.
      *
      * The returned mesh can be specified in a #khepri::renderer::MeshInstance to be rendered.
      *
@@ -111,6 +113,18 @@ public:
      * \return the created mesh.
      */
     virtual std::unique_ptr<Mesh> create_mesh(const MeshDesc& mesh_desc) = 0;
+
+    /**
+     * \brief Create a render pipeline.
+     *
+     * See \see khepri::renderer::RenderPipelineDesc for an explanation of render pipelines.
+     *
+     * \param render_pipeline_desc the render pipeline to create.
+     *
+     * \throw ArgumentError if \a render_pipeline_desc contains an invalid description.
+     */
+    virtual std::unique_ptr<RenderPipeline>
+    create_render_pipeline(const RenderPipelineDesc& render_pipeline_desc) = 0;
 
     /**
      * Clears the render target and/or depth/stencil buffer
@@ -125,22 +139,32 @@ public:
     virtual void present() = 0;
 
     /**
-     * Renders a collection of meshe instances.
+     * Renders a collection of mesh instances.
      *
+     * \param[in] render_pipeline the render pipeline to use
      * \param[in] meshes a collection of mesh instances to render.
      * \param[in] camera the camera to render them with.
+     *
+     * \throws ArgumentError if any meshes use materials that were created by a different
+     *                       render pipeline, or if the render pipeline was not created by
+     *                       this renderer.
      */
-    virtual void render_meshes(gsl::span<const MeshInstance> meshes, const Camera& camera) = 0;
+    virtual void render_meshes(RenderPipeline&               render_pipeline,
+                               gsl::span<const MeshInstance> meshes, const Camera& camera) = 0;
 
     /**
      * Renders a collection of sprites in camera-space
      *
+     * \param[in] render_pipeline the render pipeline to use
      * \param[in] sprites a collection of sprites to render.
      * \param[in] material the material to render the sprites with.
      * \param[in] params the material parameters to render the sprites with.
+     *
+     * \throws ArgumentError if the material was created by a different render pipeline, or
+     *                       if the render pipeline was not created by this renderer.
      */
-    virtual void render_sprites(gsl::span<const Sprite> sprites, Material& material,
-                                gsl::span<const Material::Param> params) = 0;
+    virtual void render_sprites(RenderPipeline& render_pipeline, gsl::span<const Sprite> sprites,
+                                Material& material, gsl::span<const Material::Param> params) = 0;
 };
 
 } // namespace khepri::renderer

--- a/khepri/include/khepri/renderer/shader.hpp
+++ b/khepri/include/khepri/renderer/shader.hpp
@@ -16,10 +16,11 @@ public:
     Shader()          = default;
     virtual ~Shader() = default;
 
-    Shader(const Shader&)            = delete;
-    Shader(Shader&&)                 = delete;
-    Shader& operator=(const Shader&) = delete;
-    Shader& operator=(Shader&&)      = delete;
+protected:
+    Shader(const Shader&)            = default;
+    Shader(Shader&&)                 = default;
+    Shader& operator=(const Shader&) = default;
+    Shader& operator=(Shader&&)      = default;
 };
 
 } // namespace khepri::renderer

--- a/khepri/include/khepri/renderer/texture.hpp
+++ b/khepri/include/khepri/renderer/texture.hpp
@@ -22,16 +22,17 @@ public:
     explicit Texture(const Size& size) : m_size(size) {}
     virtual ~Texture() = default;
 
-    Texture(const Texture&)            = delete;
-    Texture(Texture&&)                 = delete;
-    Texture& operator=(const Texture&) = delete;
-    Texture& operator=(Texture&&)      = delete;
-
     /// Retrieves the size of the texture
     [[nodiscard]] const Size& size() const noexcept
     {
         return m_size;
     }
+
+protected:
+    Texture(const Texture&)            = default;
+    Texture(Texture&&)                 = default;
+    Texture& operator=(const Texture&) = default;
+    Texture& operator=(Texture&&)      = default;
 
 private:
     Size m_size;

--- a/openglyph/CMakeLists.txt
+++ b/openglyph/CMakeLists.txt
@@ -18,8 +18,10 @@ add_library(${PROJECT_NAME}
     src/io/chunk_reader.cpp
     src/renderer/io/material.cpp
     src/renderer/io/model.cpp
+    src/renderer/io/render_pipeline.cpp
     src/renderer/material_store.cpp
     src/renderer/model_creator.cpp
+    src/renderer/render_pipeline_store.cpp
     src/parser/parsers.cpp
     src/parser/xml_parser.cpp
     src/ui/input.cpp

--- a/openglyph/include/openglyph/assets/asset_cache.hpp
+++ b/openglyph/include/openglyph/assets/asset_cache.hpp
@@ -7,6 +7,7 @@
 
 #include <openglyph/renderer/material_store.hpp>
 #include <openglyph/renderer/model_creator.hpp>
+#include <openglyph/renderer/render_pipeline_store.hpp>
 
 namespace openglyph {
 
@@ -29,6 +30,8 @@ public:
     AssetCache& operator=(AssetCache&&)      = delete;
     ~AssetCache();
 
+    khepri::renderer::RenderPipeline* get_render_pipeline(std::string_view name);
+
     khepri::renderer::Material* get_material(std::string_view name);
 
     khepri::renderer::Texture* get_texture(std::string_view name);
@@ -38,6 +41,7 @@ public:
 private:
     khepri::OwningCache<khepri::renderer::Shader>         m_shader_cache;
     khepri::OwningCache<khepri::renderer::Texture>        m_texture_cache;
+    openglyph::renderer::RenderPipelineStore              m_render_pipelines;
     openglyph::renderer::MaterialStore                    m_materials;
     openglyph::renderer::ModelCreator                     m_model_creator;
     khepri::OwningCache<openglyph::renderer::RenderModel> m_render_model_cache;

--- a/openglyph/include/openglyph/game/scene_renderer.hpp
+++ b/openglyph/include/openglyph/game/scene_renderer.hpp
@@ -10,7 +10,11 @@ namespace openglyph {
 class SceneRenderer
 {
 public:
-    explicit SceneRenderer(khepri::renderer::Renderer& renderer) : m_renderer(renderer) {}
+    SceneRenderer(khepri::renderer::Renderer&       renderer,
+                  khepri::renderer::RenderPipeline& render_pipeline)
+        : m_renderer(renderer), m_render_pipeline(render_pipeline)
+    {
+    }
     ~SceneRenderer() = default;
 
     SceneRenderer(const SceneRenderer&)                = delete;
@@ -24,7 +28,8 @@ private:
     void render_scene(const khepri::scene::Scene& scene, const openglyph::Environment& environment,
                       const khepri::renderer::Camera& camera);
 
-    khepri::renderer::Renderer& m_renderer;
+    khepri::renderer::Renderer&       m_renderer;
+    khepri::renderer::RenderPipeline& m_render_pipeline;
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/renderer/io/render_pipeline.hpp
+++ b/openglyph/include/openglyph/renderer/io/render_pipeline.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <khepri/io/stream.hpp>
+#include <khepri/renderer/render_pipeline_desc.hpp>
+
+#include <vector>
+
+namespace openglyph::renderer::io {
+
+std::vector<khepri::renderer::RenderPipelineDesc>
+load_render_pipelines(khepri::io::Stream& xml_stream);
+
+} // namespace openglyph::renderer::io

--- a/openglyph/include/openglyph/renderer/material_desc.hpp
+++ b/openglyph/include/openglyph/renderer/material_desc.hpp
@@ -15,10 +15,6 @@ struct MaterialDesc
     using PropertyValue = std::variant<std::int32_t, float, khepri::Vector2f, khepri::Vector3f,
                                        khepri::Vector4f, khepri::Matrixf, std::string>;
 
-    using AlphaBlendMode  = khepri::renderer::MaterialDesc::AlphaBlendMode;
-    using ComparisonFunc  = khepri::renderer::MaterialDesc::ComparisonFunc;
-    using DepthBufferDesc = khepri::renderer::MaterialDesc::DepthBufferDesc;
-
     /// Description of a material shader property
     struct Property
     {
@@ -32,11 +28,9 @@ struct MaterialDesc
     /// Name of the material
     std::string name;
 
-    /// Type of alpha blending to use when rendering with this material
-    AlphaBlendMode alpha_blend_mode{AlphaBlendMode::none};
-
-    /// Depth-buffer settings to use when rendering this material
-    std::optional<DepthBufferDesc> depth_buffer;
+    /// The type of the material. This is only used to allow render passes in the render pipeline to
+    /// render certain materials. See #khepri::renderer::RenderPassDesc.
+    std::string type;
 
     /// Name of the shader of this material
     std::string shader;

--- a/openglyph/include/openglyph/renderer/render_pipeline_store.hpp
+++ b/openglyph/include/openglyph/renderer/render_pipeline_store.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <khepri/renderer/render_pipeline.hpp>
+#include <khepri/renderer/render_pipeline_desc.hpp>
+#include <khepri/renderer/renderer.hpp>
+#include <khepri/utility/string.hpp>
+
+#include <gsl/gsl-lite.hpp>
+
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace openglyph::renderer {
+
+class RenderPipelineStore final
+{
+public:
+    explicit RenderPipelineStore(khepri::renderer::Renderer& renderer);
+    ~RenderPipelineStore() = default;
+
+    RenderPipelineStore(const RenderPipelineStore&)                = delete;
+    RenderPipelineStore(RenderPipelineStore&&) noexcept            = delete;
+    RenderPipelineStore& operator=(const RenderPipelineStore&)     = delete;
+    RenderPipelineStore& operator=(RenderPipelineStore&&) noexcept = delete;
+
+    void
+    register_render_pipelines(gsl::span<const khepri::renderer::RenderPipelineDesc> pipeline_descs);
+
+    [[nodiscard]] khepri::renderer::RenderPipeline* get(std::string_view name) const noexcept;
+
+    auto as_loader()
+    {
+        return [this](std::string_view id) { return this->get(id); };
+    }
+
+private:
+    using RenderPipelineMap =
+        std::map<std::string, std::unique_ptr<khepri::renderer::RenderPipeline>,
+                 khepri::CaseInsensitiveLess>;
+
+    khepri::renderer::Renderer& m_renderer;
+
+    RenderPipelineMap m_render_pipelines;
+};
+
+} // namespace openglyph::renderer

--- a/openglyph/src/game/scene_renderer.cpp
+++ b/openglyph/src/game/scene_renderer.cpp
@@ -235,7 +235,7 @@ void SceneRenderer::render_scene(const khepri::scene::Scene&     scene,
         }
     }
 
-    m_renderer.render_meshes(meshes, camera);
+    m_renderer.render_meshes(m_render_pipeline, meshes, camera);
 }
 
 } // namespace openglyph

--- a/openglyph/src/renderer/io/material.cpp
+++ b/openglyph/src/renderer/io/material.cpp
@@ -48,79 +48,14 @@ struct Parser<PropertyType>
     }
 };
 
-template <>
-struct Parser<renderer::MaterialDesc::AlphaBlendMode>
-{
-    using AlphaBlendMode = renderer::MaterialDesc::AlphaBlendMode;
-
-    static std::optional<AlphaBlendMode> parse(std::string_view str) noexcept
-    {
-        if (str == "none") {
-            return AlphaBlendMode::none;
-        }
-        if (str == "blend_src") {
-            return AlphaBlendMode::blend_src;
-        }
-        if (str == "additive") {
-            return AlphaBlendMode::additive;
-        }
-        return {};
-    }
-};
-
-template <>
-struct Parser<renderer::MaterialDesc::ComparisonFunc>
-{
-    using ComparisonFunc = renderer::MaterialDesc::ComparisonFunc;
-
-    static std::optional<ComparisonFunc> parse(std::string_view str) noexcept
-    {
-        if (str == "never") {
-            return ComparisonFunc::never;
-        }
-        if (str == "less") {
-            return ComparisonFunc::less;
-        }
-        if (str == "equal") {
-            return ComparisonFunc::equal;
-        }
-        if (str == "less_equal") {
-            return ComparisonFunc::less_equal;
-        }
-        if (str == "greater") {
-            return ComparisonFunc::greater;
-        }
-        if (str == "not_equal") {
-            return ComparisonFunc::not_equal;
-        }
-        if (str == "greater_equal") {
-            return ComparisonFunc::greater_equal;
-        }
-        if (str == "always") {
-            return ComparisonFunc::always;
-        }
-        return {};
-    }
-};
-
 namespace renderer::io {
 
 namespace {
 auto load_material(const openglyph::XmlParser::Node& node)
 {
     struct MaterialDesc material_desc;
-    material_desc.name             = require_attribute(node, "Name");
-    material_desc.alpha_blend_mode = openglyph::parse<MaterialDesc::AlphaBlendMode>(
-        optional_attribute(node, "AlphaBlend", "none"));
-
-    if (openglyph::parse<bool>(optional_attribute(node, "DepthEnable", "true"))) {
-        MaterialDesc::DepthBufferDesc desc{};
-        desc.comparison_func = openglyph::parse<MaterialDesc::ComparisonFunc>(
-            optional_attribute(node, "DepthFunc", "less"));
-        desc.write_enable =
-            openglyph::parse<bool>(optional_attribute(node, "DepthWriteEnable", "true"));
-        material_desc.depth_buffer = desc;
-    }
+    material_desc.name = require_attribute(node, "Name");
+    material_desc.type = optional_attribute(node, "Type", "");
 
     for (const auto& propnode : node.nodes()) {
         if (propnode.name() == "Shader") {

--- a/openglyph/src/renderer/io/render_pipeline.cpp
+++ b/openglyph/src/renderer/io/render_pipeline.cpp
@@ -1,0 +1,136 @@
+#include <khepri/log/log.hpp>
+
+#include <openglyph/parser/parsers.hpp>
+#include <openglyph/parser/xml_parser.hpp>
+#include <openglyph/renderer/io/render_pipeline.hpp>
+
+namespace openglyph {
+template <>
+struct Parser<khepri::renderer::RenderPassDesc::DepthSorting>
+{
+    using DepthSorting = khepri::renderer::RenderPassDesc::DepthSorting;
+
+    static std::optional<DepthSorting> parse(std::string_view str) noexcept
+    {
+        if (khepri::case_insensitive_equals(str, "none")) {
+            return DepthSorting::none;
+        }
+        if (khepri::case_insensitive_equals(str, "front_to_back")) {
+            return DepthSorting::front_to_back;
+        }
+        if (khepri::case_insensitive_equals(str, "back_to_front")) {
+            return DepthSorting::back_to_front;
+        }
+        return {};
+    }
+};
+
+template <>
+struct Parser<khepri::renderer::RenderPassDesc::AlphaBlendMode>
+{
+    using AlphaBlendMode = khepri::renderer::RenderPassDesc::AlphaBlendMode;
+
+    static std::optional<AlphaBlendMode> parse(std::string_view str) noexcept
+    {
+        if (khepri::case_insensitive_equals(str, "none")) {
+            return AlphaBlendMode::none;
+        }
+        if (khepri::case_insensitive_equals(str, "blend_src")) {
+            return AlphaBlendMode::blend_src;
+        }
+        if (khepri::case_insensitive_equals(str, "additive")) {
+            return AlphaBlendMode::additive;
+        }
+        return {};
+    }
+};
+
+template <>
+struct Parser<khepri::renderer::RenderPassDesc::ComparisonFunc>
+{
+    using ComparisonFunc = khepri::renderer::RenderPassDesc::ComparisonFunc;
+
+    static std::optional<ComparisonFunc> parse(std::string_view str) noexcept
+    {
+        if (khepri::case_insensitive_equals(str, "never")) {
+            return ComparisonFunc::never;
+        }
+        if (khepri::case_insensitive_equals(str, "less")) {
+            return ComparisonFunc::less;
+        }
+        if (khepri::case_insensitive_equals(str, "equal")) {
+            return ComparisonFunc::equal;
+        }
+        if (khepri::case_insensitive_equals(str, "less_equal")) {
+            return ComparisonFunc::less_equal;
+        }
+        if (khepri::case_insensitive_equals(str, "greater")) {
+            return ComparisonFunc::greater;
+        }
+        if (khepri::case_insensitive_equals(str, "not_equal")) {
+            return ComparisonFunc::not_equal;
+        }
+        if (khepri::case_insensitive_equals(str, "greater_equal")) {
+            return ComparisonFunc::greater_equal;
+        }
+        if (khepri::case_insensitive_equals(str, "always")) {
+            return ComparisonFunc::always;
+        }
+        return {};
+    }
+};
+
+namespace renderer::io {
+namespace {
+auto load_render_pass(const openglyph::XmlParser::Node& node)
+{
+    khepri::renderer::RenderPassDesc render_pass;
+    render_pass.material_type = optional_child(node, "Material_Type", "");
+    render_pass.depth_sorting = parse<khepri::renderer::RenderPassDesc::DepthSorting>(
+        optional_child(node, "Depth_Sort", "None"));
+    render_pass.alpha_blend_mode = parse<khepri::renderer::RenderPassDesc::AlphaBlendMode>(
+        optional_child(node, "AlphaBlend", "none"));
+
+    if (openglyph::parse<bool>(optional_child(node, "DepthEnable", "true"))) {
+        khepri::renderer::RenderPassDesc::DepthBufferDesc desc{};
+        desc.comparison_func = parse<khepri::renderer::RenderPassDesc::ComparisonFunc>(
+            optional_child(node, "DepthFunc", "less"));
+        desc.write_enable        = parse<bool>(optional_child(node, "DepthWriteEnable", "true"));
+        render_pass.depth_buffer = desc;
+    }
+
+    return render_pass;
+}
+
+auto load_render_pipeline(const openglyph::XmlParser::Node& node)
+{
+    khepri::renderer::RenderPipelineDesc render_pipeline_desc;
+    render_pipeline_desc.name = require_attribute(node, "Name");
+    for (const auto& child : node.nodes()) {
+        render_pipeline_desc.render_passes.push_back(load_render_pass(child));
+    }
+    return render_pipeline_desc;
+}
+
+constexpr khepri::log::Logger LOG("renderer");
+} // namespace
+
+std::vector<khepri::renderer::RenderPipelineDesc>
+load_render_pipelines(khepri::io::Stream& xml_stream)
+{
+    std::vector<khepri::renderer::RenderPipelineDesc> render_pipelines;
+    try {
+        const openglyph::XmlParser xml(xml_stream);
+        if (const auto& root = xml.root()) {
+            for (const auto& node : root->nodes()) {
+                render_pipelines.push_back(load_render_pipeline(node));
+            }
+        }
+    } catch (const openglyph::ParseError& e) {
+        LOG.error("parse error: {}", e.what());
+    }
+    return render_pipelines;
+}
+
+} // namespace renderer::io
+} // namespace openglyph

--- a/openglyph/src/renderer/material_store.cpp
+++ b/openglyph/src/renderer/material_store.cpp
@@ -26,10 +26,8 @@ void MaterialStore::register_materials(
 {
     for (const auto& desc : material_descs) {
         khepri::renderer::MaterialDesc info;
-        info.cull_mode        = khepri::renderer::MaterialDesc::CullMode::front;
-        info.alpha_blend_mode = desc.alpha_blend_mode;
-        info.depth_buffer     = desc.depth_buffer;
-        info.shader           = m_shader_loader(desc.shader);
+        info.type   = desc.type;
+        info.shader = m_shader_loader(desc.shader);
         for (const auto& property : desc.properties) {
             khepri::renderer::MaterialDesc::Property prop;
             prop.name = property.name;

--- a/openglyph/src/renderer/render_pipeline_store.cpp
+++ b/openglyph/src/renderer/render_pipeline_store.cpp
@@ -1,0 +1,24 @@
+#include <openglyph/renderer/render_pipeline_store.hpp>
+
+namespace openglyph::renderer {
+
+RenderPipelineStore::RenderPipelineStore(khepri::renderer::Renderer& renderer)
+    : m_renderer(renderer)
+{
+}
+
+void RenderPipelineStore::register_render_pipelines(
+    gsl::span<const khepri::renderer::RenderPipelineDesc> pipeline_descs)
+{
+    for (const auto& desc : pipeline_descs) {
+        m_render_pipelines.emplace(desc.name, m_renderer.create_render_pipeline(desc));
+    }
+}
+
+khepri::renderer::RenderPipeline* RenderPipelineStore::get(std::string_view name) const noexcept
+{
+    const auto it = m_render_pipelines.find(name);
+    return (it != m_render_pipelines.end()) ? it->second.get() : nullptr;
+}
+
+} // namespace openglyph::renderer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,7 +218,13 @@ int main(int argc, const char* argv[])
 
         std::unique_ptr<openglyph::Scene> scene =
             CreateScene("_MP_SPACE_ALDERAAN", asset_loader, asset_cache, game_object_types);
-        openglyph::SceneRenderer scene_renderer(renderer);
+
+        auto render_pipeline = asset_cache.get_render_pipeline("Default");
+        if (!render_pipeline) {
+            // We can't render without a pipeline, so this is a fatal error
+            throw std::runtime_error("Unable to load default render pipeline");
+        }
+        openglyph::SceneRenderer scene_renderer(renderer, *render_pipeline);
 
         std::chrono::steady_clock::time_point last_update_time = std::chrono::steady_clock::now();
         double                                unhandled_update_time = 0.0;


### PR DESCRIPTION
This change introduces render pipelines, an XML-configurable collection of render passes that draw meshes in a certain way.

The options at the moment are limited (alpha blending, depth sorting, etc), but this already allows transparent meshes to be properly drawn on top of solid meshes, instead of being arbitrarily drawn before or after. Most of the settings have been migrated from Materials.xml to the new RenderPipelines.xml. Materials.xml now define the shaders and shader parameters.

This concept can later be extended with post-processing steps and so on.