### PR TITLE
fix: incorrect sun_glow billboarding

### DIFF
--- a/openglyph/src/game/scene_renderer.cpp
+++ b/openglyph/src/game/scene_renderer.cpp
@@ -156,7 +156,7 @@ void apply_billboard(khepri::Matrixf& transform, const renderer::RenderModel::Me
     case renderer::BillboardMode::sun_glow: {
         // Get offset from the parent bone (maintain scaling of final transformation)
         const auto offset_from_parent =
-            mesh.parent_transform.get_translation() * transform.get_scale();
+            mesh.parent_transform.get_translation() * transform.get_rotation_scale();
         const auto distance = offset_from_parent.length();
         // Rotate the object around its parent towards the main light
         transform.set_translation(transform.get_translation() - offset_from_parent +


### PR DESCRIPTION
Meshes that used sun_glow billboarding were incorrectly positioned. The mesh had to be translated back to the parent's position (in object space), but the vector calculation to do so in world space ignored the object's rotation. This has been fixed.