### PR TITLE
fix: add specular lighting

### DIFF
--- a/data-extra/Data/Art/Shaders/MeshGloss.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshGloss.hlsl
@@ -7,7 +7,6 @@ cbuffer Material
 	float3 Emissive;
 	float3 Diffuse;
 	float3 Specular;
-	float  Shininess;
 };
 
 Texture2D BaseTexture;
@@ -29,13 +28,16 @@ struct VS_OUTPUT
 	float4 Pos : SV_Position; // Position (camera space)
 	float2 UV : TEXCOORD1; // Texture coordinates (tangent space)
 	float3 Diffuse: COLOR0;
+	float3 Spec: COLOR1;
 };
 
 VS_OUTPUT vs_main(VS_INPUT_MESH In)
 {
 	VS_OUTPUT Out;
 
+	float4 world_pos = mul(float4(In.Pos, 1), World);
 	float3 world_normal = normalize(mul(In.Normal, (float3x3)World));
+	float3 camera_pos = camera_position();
 
 	// No bump mapping, so calculate all lights per-vertex
 	float3 diff_light =
@@ -43,15 +45,19 @@ VS_OUTPUT vs_main(VS_INPUT_MESH In)
 	    DirectionalLights[1].intensity * DirectionalLights[1].diffuse_color * saturate(dot(world_normal, -DirectionalLights[1].direction)) +
 	    DirectionalLights[2].intensity * DirectionalLights[2].diffuse_color * saturate(dot(world_normal, -DirectionalLights[2].direction));
 
-	Out.Pos = mul(float4(In.Pos, 1), mul(World, ViewProj));
+    float3 light_half_vec = light_half_angle((float3)world_pos, camera_pos, -DirectionalLights[0].direction);
+
+	Out.Pos = mul(world_pos, ViewProj);
 	Out.UV = In.UV;
 	Out.Diffuse = Diffuse * diff_light + Emissive;
-
+	Out.Spec = Specular * DirectionalLights[0].intensity * DirectionalLights[0].specular_color * pow(max(0, dot(world_normal, light_half_vec)), 16);
 	return Out;
 }
 
 float4 ps_main(VS_OUTPUT In) : SV_Target
 {
-	float4 texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
-	return float4(texel.rgb * In.Diffuse, 1);
+	float4 base_texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
+	float3 diffuse = In.Diffuse * base_texel.rgb;
+	float3 specular = In.Spec * base_texel.a;
+	return float4(diffuse + specular, 1);
 }

--- a/data-extra/Data/Art/Shaders/common.hlsli
+++ b/data-extra/Data/Art/Shaders/common.hlsli
@@ -48,6 +48,12 @@ cbuffer EnvironmentConstants
     float Time;
 };
 
+// Returns the camera position, in world space
+float3 camera_position() {
+    // The line below basically does "ViewProjInv.transform_coord({0,0,0})"
+    return ViewProjInv[3].xyz / ViewProjInv[3].w;
+}
+
 // Encodes a (assumed normalized) vector for storage in a TEXCOORD attribute
 float3 encode_vector(float3 vec)
 {
@@ -89,9 +95,9 @@ float3x3 to_tangent_matrix(float3 tangent, float3 binormal, float3 normal)
 }
 
 // Compute the light half-angle vector (for specular calculation).
-float3 light_half_angle(float3 vertex_pos, float3 eye_pos, float3 light_pos)
+// All vectors must be in the same space.
+float3 light_half_angle(float3 vertex_pos, float3 eye_pos, float3 light_dir)
 {
     float3 V = normalize(eye_pos - vertex_pos); // vector from vertex to eye
-    float3 L = normalize(light_pos - vertex_pos); // vector from vertex to light source
-    return normalize(V + L);
+    return normalize(V + light_dir);
 }

--- a/data-extra/Data/XML/Materials.xml
+++ b/data-extra/Data/XML/Materials.xml
@@ -21,8 +21,11 @@
     <Material Name="MeshBumpColorize" Type="Opaque">
         <Shader>MeshBumpColorize</Shader>
         <Num_Directional_Lights>3</Num_Directional_Lights>
-        <Param Name="Colorization" Type="float3">1, 1, 1</Param>
+        <Param Name="Emissive" Type="float3">0, 0, 0</Param>
         <Param Name="Diffuse" Type="float3">1, 1, 1</Param>
+        <Param Name="Specular" Type="float3">1, 1, 1</Param>
+        <Param Name="Colorization" Type="float3">0, 1, 0</Param>
+        <Param Name="UVOffset" Type="float2">0, 0</Param>
         <Param Name="BaseTexture" Type="texture"></Param>
         <Param Name="NormalTexture" Type="texture"></Param>
     </Material>
@@ -33,7 +36,6 @@
         <Param Name="Emissive" Type="float3">0, 0, 0</Param>
         <Param Name="Diffuse" Type="float3">1, 1, 1</Param>
         <Param Name="Specular" Type="float3">0, 0, 0</Param>
-        <Param Name="Shininess" Type="float">1</Param>
         <Param Name="BaseTexture" Type="texture"></Param>
     </Material>
 


### PR DESCRIPTION
This change modifies the MeshBumpColorize and MeshGloss shaders to have specular lighting. Also modifies the MeshBumpColorize shader to add and use its missing properties such as Colorization.