### PR TITLE
fix: normal maps are read in sRGB space

### DIFF
--- a/data-extra/Data/Art/Shaders/MeshBumpColorize.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshBumpColorize.hlsl
@@ -82,7 +82,7 @@ float4 ps_main(VS_OUTPUT In) : SV_Target
 	float3 half_vec = decode_vector(In.HalfAngleVector);
 
 	// Calculate main light in pixel shader to use normal map
-	float3 diffuse = surface_color * (In.Diff + DirectionalLights[0].intensity * DirectionalLights[0].diffuse_color * saturate(dot(normal, light_dir)));
+	float3 diffuse = surface_color * (In.Diff + DirectionalLights[0].intensity * DirectionalLights[0].diffuse_color * saturate(dot(normal, light_dir))) * 2;
 	float3 spec = normal_texel.a * Specular * DirectionalLights[0].intensity * DirectionalLights[0].specular_color * pow(saturate(dot(normal, half_vec)), 16);
 	return float4(diffuse + spec, 1);
 }

--- a/data-extra/Data/Art/Shaders/MeshGloss.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshGloss.hlsl
@@ -57,7 +57,7 @@ VS_OUTPUT vs_main(VS_INPUT_MESH In)
 float4 ps_main(VS_OUTPUT In) : SV_Target
 {
 	float4 base_texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
-	float3 diffuse = In.Diffuse * base_texel.rgb;
+	float3 diffuse = In.Diffuse * base_texel.rgb * 2;
 	float3 specular = In.Spec * base_texel.a;
 	return float4(diffuse + specular, 1);
 }

--- a/khepri/CMakeLists.txt
+++ b/khepri/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(${PROJECT_NAME}
     src/renderer/io/shader.cpp
     src/renderer/camera.cpp
     src/renderer/model.cpp
+    src/renderer/texture_desc.cpp
     src/renderer/diligent/native_window.cpp
     src/renderer/diligent/renderer.cpp
     src/scene/scene_object.cpp

--- a/khepri/include/khepri/math/color_rgba.hpp
+++ b/khepri/include/khepri/math/color_rgba.hpp
@@ -4,6 +4,8 @@
 
 namespace khepri {
 
+class ColorSRGBA;
+
 /**
  * \brief An RGBA color
  *
@@ -49,6 +51,14 @@ public:
         : r(c.r), g(c.g), b(c.b), a(fa)
     {
     }
+
+    /**
+     * Constructs a ColorRGBA from a ColorSRGBA by performing sRGB-to-linear conversion (except for
+     * the alpha component).
+     *
+     * \note the components of the resulting color are in the domain [0,1].
+     */
+    explicit constexpr ColorRGBA(const ColorSRGBA& c) noexcept;
 
     /// Adds color \a c to the vector
     ColorRGBA& operator+=(const ColorRGBA& c) noexcept

--- a/khepri/include/khepri/math/color_srgba.hpp
+++ b/khepri/include/khepri/math/color_srgba.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "color_rgb.hpp"
+#include "color_srgb.hpp"
+#include "math.hpp"
+
+#include <cstdint>
+
+namespace khepri {
+
+/**
+ * \brief An sRGB+A color
+ *
+ * This color is in \a sRGB space, so mathematical operations are not defined to avoid incorrect
+ * results. The Alpha component is in linear space as it is a fraction, not a color.
+ * sRGB colors can be displayed to the user, but must be converted to a \ref ColorRGBA in order to
+ * perform mathematical operations with it.
+ *
+ * Unlike \ref ColorRGBA, this class stores its contents with an 8 bit integer per channel in
+ * accordance with most sRGB+A output channels. This class is similar to \ref BasicVector4, except
+ * it describes the semantics of its contents, and it does not provide any mathematical operations.
+ *
+ * \note This class does \a not clamp results after mathematical operations to the [0,1] range.
+ */
+#pragma pack(push, 1)
+class ColorSRGBA final
+{
+public:
+    /// The type of the color's components
+    using ComponentType = std::uint8_t;
+
+    /// The red component of the color
+    ComponentType r{};
+
+    /// The green component of the color
+    ComponentType g{};
+
+    /// The blue component of the color
+    ComponentType b{};
+
+    /// The alpha component of the color
+    ComponentType a{};
+
+    /// Constructs an uninitialized ColorSRGBA
+    constexpr ColorSRGBA() noexcept = default;
+
+    /// Constructs the ColorSRGBA from literals
+    constexpr ColorSRGBA(ComponentType fr, ComponentType fg, ComponentType fb,
+                         ComponentType fa) noexcept
+        : r(fr), g(fg), b(fb), a(fa)
+    {
+    }
+
+    /// Constructs the ColorSRGBA from a ColorSRGB, and an Alpha component
+    constexpr ColorSRGBA(const ColorSRGB& c, ComponentType fa) noexcept
+        : r(c.r), g(c.g), b(c.b), a(fa)
+    {
+    }
+
+    /**
+     * Constructs a ColorSRGBA from a ColorRGBA by performing linear-to-sRGB conversion (except for
+     * the alpha component).
+     *
+     * \note the components of the color are clamped to [0,1] before conversion.
+     */
+    explicit constexpr ColorSRGBA(const ColorRGBA& c) noexcept
+        : r(static_cast<ComponentType>(ColorSRGB::linear_to_srgb(saturate(c.r)) *
+                                       std::numeric_limits<ColorSRGBA::ComponentType>::max()))
+        , g(static_cast<ComponentType>(ColorSRGB::linear_to_srgb(saturate(c.g)) *
+                                       std::numeric_limits<ColorSRGBA::ComponentType>::max()))
+        , b(static_cast<ComponentType>(ColorSRGB::linear_to_srgb(saturate(c.b)) *
+                                       std::numeric_limits<ColorSRGBA::ComponentType>::max()))
+        , a(static_cast<ComponentType>(saturate(c.a) *
+                                       std::numeric_limits<ColorSRGBA::ComponentType>::max()))
+    {
+    }
+
+    /// Indexes the color. 0 is Red, 1 is Green, etc
+    const ComponentType& operator[](int index) const noexcept
+    {
+        assert(index < 4);
+        return gsl::span<const ComponentType>(&r, 4)[index];
+    }
+
+    /// Indexes the color. 0 is Red, 1 is Green, etc
+    ComponentType& operator[](int index) noexcept
+    {
+        assert(index < 4);
+        return gsl::span<ComponentType>(&r, 4)[index];
+    }
+};
+#pragma pack(pop)
+
+constexpr ColorRGBA::ColorRGBA(const ColorSRGBA& c) noexcept
+    : r(ColorSRGB::srgb_to_linear(static_cast<float>(c.r) /
+                                  std::numeric_limits<ColorSRGBA::ComponentType>::max()))
+    , g(ColorSRGB::srgb_to_linear(static_cast<float>(c.g) /
+                                  std::numeric_limits<ColorSRGBA::ComponentType>::max()))
+    , b(ColorSRGB::srgb_to_linear(static_cast<float>(c.b) /
+                                  std::numeric_limits<ColorSRGBA::ComponentType>::max()))
+    , a(static_cast<float>(c.a) / std::numeric_limits<ColorSRGBA::ComponentType>::max())
+{
+}
+
+} // namespace khepri

--- a/khepri/include/khepri/renderer/diligent/renderer.hpp
+++ b/khepri/include/khepri/renderer/diligent/renderer.hpp
@@ -19,6 +19,7 @@ public:
      * Constructs the Diligent-based renderer.
      *
      * \param[in] window the native window to create the renderer in
+     * \param[in] color_space the color space for the output buffer.
      *
      * \throws khepri::ArgumentError if \a window does not contain the expected type
      * \throws khepri::renderer::Error if the renderer could not be created
@@ -27,8 +28,12 @@ public:
      * - Windows: a HWND is expected.
      * - Linux:   a std::tuple<void*, std::uint32_t> is expected where the first element is
      *            the X11 display pointer and the second element is the X11 window ID.
+     *
+     * The \a color_space argument matters to determine if gamma conversion is to be performed on
+     * the rendered pixels. If the color space is srgb, gamma conversion will be performed. In
+     * linear mode, the shader logic has to make sure the pixels are suitably converted for display.
      */
-    Renderer(const std::any& window);
+    Renderer(const std::any& window, ColorSpace color_space);
     ~Renderer() override;
 
     Renderer(const Renderer&)            = delete;

--- a/khepri/include/khepri/renderer/io/texture.hpp
+++ b/khepri/include/khepri/renderer/io/texture.hpp
@@ -6,6 +6,29 @@
 namespace khepri ::renderer ::io {
 
 /**
+ * Options for loading a texture
+ */
+struct TextureLoadOptions
+{
+    /**
+     * Some textures may be in an unknown color space.
+     *
+     * For instance, DDS textures without DX10 header. Or BMP, TGA, etc. This field decides which
+     * variant of pixel formats those textures are assigned.
+     *
+     * The choice of this field depends on how the texture is used. For instance, color textures
+     * (e.g. diffuse textures) should typically be read in sRGB space to benefit from hardware gamma
+     * conversion in shaders. But normal maps should be read in linear space, because they're
+     * storing vectors, not colors.
+     *
+     * \note to be clear, this field does not convert the texture data from one space to another,
+     * but merely provides the default color space for the resulting texture's pixel format **if and
+     * only if** the file format doesn't specify one.
+     */
+    ColorSpace default_color_space{ColorSpace::srgb};
+};
+
+/**
  * Loads a texture description from a stream.
  *
  * Only the DDS and TARGA formats are supported by this function.
@@ -13,7 +36,7 @@ namespace khepri ::renderer ::io {
  * @throw khepri::argument_error the stream is not readable and seekable.
  * @throw khepri::io::invalid_format the stream is not a valid texture.
  */
-TextureDesc load_texture(khepri::io::Stream& stream);
+TextureDesc load_texture(khepri::io::Stream& stream, const TextureLoadOptions& options);
 
 /**
  * Possible texture formats for #save_texture

--- a/khepri/src/renderer/diligent/renderer.cpp
+++ b/khepri/src/renderer/diligent/renderer.cpp
@@ -115,14 +115,24 @@ RESOURCE_DIMENSION to_resource_dimension(TextureDimension dimension, bool is_arr
 TEXTURE_FORMAT to_texture_format(PixelFormat format)
 {
     switch (format) {
+    case PixelFormat::r8g8b8a8_unorm:
+        return TEX_FORMAT_RGBA8_UNORM;
     case PixelFormat::r8g8b8a8_unorm_srgb:
         return TEX_FORMAT_RGBA8_UNORM_SRGB;
+    case PixelFormat::b8g8r8a8_unorm:
+        return TEX_FORMAT_BGRA8_UNORM;
     case PixelFormat::b8g8r8a8_unorm_srgb:
         return TEX_FORMAT_BGRA8_UNORM_SRGB;
+    case PixelFormat::bc1_unorm:
+        return TEX_FORMAT_BC1_UNORM;
     case PixelFormat::bc1_unorm_srgb:
         return TEX_FORMAT_BC1_UNORM_SRGB;
+    case PixelFormat::bc2_unorm:
+        return TEX_FORMAT_BC2_UNORM;
     case PixelFormat::bc2_unorm_srgb:
         return TEX_FORMAT_BC2_UNORM_SRGB;
+    case PixelFormat::bc3_unorm:
+        return TEX_FORMAT_BC3_UNORM;
     case PixelFormat::bc3_unorm_srgb:
         return TEX_FORMAT_BC3_UNORM_SRGB;
     }
@@ -574,7 +584,7 @@ class Renderer::Impl
     };
 
 public:
-    Impl(const std::any& window)
+    Impl(const std::any& window, ColorSpace color_space)
     {
         SetDebugMessageCallback(diligent_debug_message_callback);
         const auto native_window = get_native_window(window);
@@ -588,7 +598,9 @@ public:
 #endif
         factory->CreateDeviceAndContextsD3D11(engine_ci, &m_device, &m_context);
 
-        SwapChainDesc      swapchain_desc;
+        SwapChainDesc swapchain_desc;
+        swapchain_desc.ColorBufferFormat =
+            to_texture_format(to_color_space(PixelFormat::r8g8b8a8_unorm_srgb, color_space));
         FullScreenModeDesc fullscreenmode_desc;
         factory->CreateSwapChainD3D11(m_device, m_context, swapchain_desc, fullscreenmode_desc,
                                       native_window, &m_swapchain);
@@ -1381,7 +1393,10 @@ private:
     DynamicLightDesc m_dynamic_light_desc{};
 };
 
-Renderer::Renderer(const std::any& window) : m_impl(std::make_unique<Impl>(window)) {}
+Renderer::Renderer(const std::any& window, ColorSpace color_space)
+    : m_impl(std::make_unique<Impl>(window, color_space))
+{
+}
 
 Renderer::~Renderer() = default;
 

--- a/khepri/src/renderer/io/texture.cpp
+++ b/khepri/src/renderer/io/texture.cpp
@@ -5,11 +5,11 @@ namespace khepri::renderer::io {
 
 // DirectDraw surface
 extern bool        is_texture_dds(khepri::io::Stream& stream);
-extern TextureDesc load_texture_dds(khepri::io::Stream& stream);
+extern TextureDesc load_texture_dds(khepri::io::Stream& stream, const TextureLoadOptions& options);
 
 // TrueVision TGA
 extern bool        is_texture_tga(khepri::io::Stream& stream);
-extern TextureDesc load_texture_tga(khepri::io::Stream& stream);
+extern TextureDesc load_texture_tga(khepri::io::Stream& stream, const TextureLoadOptions& options);
 extern void        save_texture_tga(khepri::io::Stream& stream, const TextureDesc& texture_desc,
                                     const TextureSaveOptions& options);
 
@@ -21,12 +21,12 @@ struct FormatFuncs
     bool (*check_func)(khepri::io::Stream&);
 
     // Loads a texture in this format from stream
-    TextureDesc (*load_func)(khepri::io::Stream&);
+    TextureDesc (*load_func)(khepri::io::Stream&, const TextureLoadOptions& options);
 };
 
 } // namespace
 
-TextureDesc load_texture(khepri::io::Stream& stream)
+TextureDesc load_texture(khepri::io::Stream& stream, const TextureLoadOptions& options)
 {
     if (!stream.readable() || !stream.seekable()) {
         throw ArgumentError();
@@ -39,7 +39,7 @@ TextureDesc load_texture(khepri::io::Stream& stream)
         stream.seek(0, khepri::io::SeekOrigin::begin);
         if (format.check_func(stream)) {
             stream.seek(0, khepri::io::SeekOrigin::begin);
-            return format.load_func(stream);
+            return format.load_func(stream, options);
         }
     }
     throw khepri::io::InvalidFormatError();

--- a/khepri/src/renderer/io/texture_tga.cpp
+++ b/khepri/src/renderer/io/texture_tga.cpp
@@ -127,7 +127,7 @@ bool is_texture_tga(khepri::io::Stream& stream)
     }
 }
 
-TextureDesc load_texture_tga(khepri::io::Stream& stream)
+TextureDesc load_texture_tga(khepri::io::Stream& stream, const TextureLoadOptions& options)
 {
     assert(stream.readable() && stream.seekable());
 
@@ -193,8 +193,13 @@ TextureDesc load_texture_tga(khepri::io::Stream& stream)
     std::vector<TextureDesc::Subresource> subresources{
         {0, data.size(), header.image_width * header.image_bpp / 8U, data.size()}};
 
-    return {TextureDimension::texture_2d,     header.image_width,      header.image_height, 0, 1,
-            PixelFormat::r8g8b8a8_unorm_srgb, std::move(subresources), std::move(data)};
+    // Targa doesn't store color space information, so we use the default from the provided options.
+    const auto pixel_format =
+        to_color_space(PixelFormat::r8g8b8a8_unorm_srgb, options.default_color_space);
+
+    return {
+        TextureDimension::texture_2d, header.image_width, header.image_height, 0, 1, pixel_format,
+        std::move(subresources),      std::move(data)};
 }
 
 void save_texture_tga(khepri::io::Stream& stream, const TextureDesc& texture_desc,

--- a/khepri/src/renderer/texture_desc.cpp
+++ b/khepri/src/renderer/texture_desc.cpp
@@ -1,0 +1,382 @@
+#include <khepri/renderer/texture_desc.hpp>
+
+namespace khepri::renderer {
+namespace {
+template <typename T>
+struct ColorTraits
+{};
+
+template <>
+struct ColorTraits<ColorRGBA>
+{
+    static ColorRGBA from_r8g8b8a8(std::uint8_t r, std::uint8_t g, std::uint8_t b,
+                                   std::uint8_t a) noexcept
+    {
+        return {static_cast<float>(r) / 255.0f, static_cast<float>(g) / 255.0f,
+                static_cast<float>(b) / 255.0f, static_cast<float>(a) / 255.0f};
+    }
+
+    static ColorRGBA from_float(float r, float g, float b, float a) noexcept
+    {
+        return {r, g, b, a};
+    }
+};
+
+template <>
+struct ColorTraits<ColorSRGBA>
+{
+    static ColorSRGBA from_r8g8b8a8(std::uint8_t r, std::uint8_t g, std::uint8_t b,
+                                    std::uint8_t a) noexcept
+    {
+        return {r, g, b, a};
+    }
+
+    static ColorSRGBA from_float(float r, float g, float b, float a) noexcept
+    {
+        return {static_cast<std::uint8_t>(r * 255), static_cast<std::uint8_t>(g * 255),
+                static_cast<std::uint8_t>(b * 255), static_cast<std::uint8_t>(a * 255)};
+    }
+};
+
+// Converts a 16-bit (5:6:5) color to a ColorRGB type
+ColorSRGB to_color(unsigned int value) noexcept
+{
+    const unsigned int r5 = (value >> 11) & 0x1F;
+    const unsigned int g6 = (value >> 5) & 0x3F;
+    const unsigned int b5 = value & 0x1F;
+
+    return {static_cast<std::uint8_t>(r5 * 255 / 31), static_cast<std::uint8_t>(g6 * 255 / 63),
+            static_cast<std::uint8_t>(b5 * 255 / 31)};
+}
+
+std::uint8_t lerp(std::uint8_t from, std::uint8_t to, unsigned int from_amount,
+                  unsigned int total_amount)
+{
+    unsigned int to_amount = total_amount - from_amount;
+    return static_cast<std::uint8_t>((static_cast<unsigned int>(from) * from_amount +
+                                      static_cast<unsigned int>(to) * to_amount) /
+                                     total_amount);
+}
+
+ColorSRGB lerp(const ColorSRGB& from, const ColorSRGB& to, unsigned int from_amount,
+               unsigned int total_amount)
+{
+    return {lerp(from.r, to.r, from_amount, total_amount),
+            lerp(from.g, to.g, from_amount, total_amount),
+            lerp(from.b, to.b, from_amount, total_amount)};
+}
+
+// Reads 4 bytes and creates a BC (Block Compression) color palette
+std::array<ColorSRGBA, 4> unpack_bc1_palette(const std::uint8_t* data)
+{
+    const auto c0      = (static_cast<unsigned int>(data[1]) << 8) | data[0];
+    const auto c1      = (static_cast<unsigned int>(data[3]) << 8) | data[2];
+    const auto color_0 = to_color(c0);
+    const auto color_1 = to_color(c1);
+
+    std::array<ColorSRGBA, 4> palette;
+    palette[0] = {color_0, 255};
+    palette[1] = {color_1, 255};
+    if (c0 > c1) {
+        // Four colors
+        palette[2] = {lerp(color_0, color_1, 2, 3), 255};
+        palette[3] = {lerp(color_0, color_1, 1, 3), 255};
+    } else {
+        // Three colors, and black transparent
+        palette[2] = {lerp(color_0, color_1, 1, 2), 255};
+        palette[3] = {0, 0, 0, 0};
+    }
+    return palette;
+}
+
+// Reads 2 bytes and creates a BC4 palette
+std::array<std::uint8_t, 8> unpack_bc4_palette(const std::uint8_t* data)
+{
+    std::array<std::uint8_t, 8> palette;
+    palette[0] = data[0];
+    palette[1] = data[1];
+    if (palette[0] > palette[1]) {
+        palette[2] = lerp(palette[0], palette[1], 6, 7);
+        palette[3] = lerp(palette[0], palette[1], 5, 7);
+        palette[4] = lerp(palette[0], palette[1], 4, 7);
+        palette[5] = lerp(palette[0], palette[1], 3, 7);
+        palette[6] = lerp(palette[0], palette[1], 2, 7);
+        palette[7] = lerp(palette[0], palette[1], 1, 7);
+    } else {
+        palette[2] = lerp(palette[0], palette[1], 4, 5);
+        palette[3] = lerp(palette[0], palette[1], 3, 5);
+        palette[4] = lerp(palette[0], palette[1], 2, 5);
+        palette[5] = lerp(palette[0], palette[1], 1, 5);
+        palette[6] = 0;
+        palette[7] = 255;
+    }
+    return palette;
+}
+
+// Reads and unpacks 8 bytes of a BC1 encoded block, without external alpha
+std::array<ColorSRGBA, 16> unpack_bc1_block(const std::uint8_t* data)
+{
+    const auto palette = unpack_bc1_palette(data);
+
+    std::uint32_t x =
+        (static_cast<std::uint32_t>(data[7]) << 24) | (static_cast<std::uint32_t>(data[6]) << 16) |
+        (static_cast<std::uint32_t>(data[5]) << 8) | (static_cast<std::uint32_t>(data[4]) << 0);
+
+    std::array<ColorSRGBA, 16> values;
+    for (unsigned int i = 0; i < 16; ++i, x >>= 2) {
+        values[i] = palette[x & 3];
+    }
+    return values;
+}
+
+// Reads and unpacks 8 bytes of a BC1 encoded block, with external alpha
+std::array<ColorSRGBA, 16> unpack_bc1_block(const std::uint8_t*                 data,
+                                            const std::array<std::uint8_t, 16>& alpha)
+{
+    const auto palette = unpack_bc1_palette(data);
+
+    std::uint32_t x =
+        (static_cast<std::uint32_t>(data[7]) << 24) | (static_cast<std::uint32_t>(data[6]) << 16) |
+        (static_cast<std::uint32_t>(data[5]) << 8) | (static_cast<std::uint32_t>(data[4]) << 0);
+
+    std::array<ColorSRGBA, 16> values;
+    for (unsigned int i = 0; i < 16; ++i, x >>= 2) {
+        const auto& c = palette[x & 3];
+        values[i]     = {c.r, c.g, c.b, alpha[i]};
+    }
+    return values;
+}
+
+std::array<std::uint8_t, 16> unpack_bc2_alpha(const std::uint8_t* data)
+{
+    std::uint64_t x =
+        (static_cast<std::uint64_t>(data[7]) << 56) | (static_cast<std::uint64_t>(data[6]) << 48) |
+        (static_cast<std::uint64_t>(data[5]) << 40) | (static_cast<std::uint64_t>(data[4]) << 32) |
+        (static_cast<std::uint64_t>(data[3]) << 24) | (static_cast<std::uint64_t>(data[2]) << 16) |
+        (static_cast<std::uint64_t>(data[1]) << 8) | static_cast<std::uint64_t>(data[0]);
+
+    std::array<std::uint8_t, 16> alpha;
+    for (auto it = alpha.begin(); it != alpha.end(); ++it, x >>= 4) {
+        *it = static_cast<std::uint8_t>((x & 0xF) * 255 / 15);
+    }
+    return alpha;
+}
+
+// Reads and unpacks 8 bytes of a BC4 encoded block
+std::array<std::uint8_t, 16> unpack_bc4_block(const std::uint8_t* data)
+{
+    const auto palette = unpack_bc4_palette(data);
+
+    std::uint64_t x =
+        (static_cast<std::uint64_t>(data[7]) << 40) | (static_cast<std::uint64_t>(data[6]) << 32) |
+        (static_cast<std::uint64_t>(data[5]) << 24) | (static_cast<std::uint64_t>(data[4]) << 16) |
+        (static_cast<std::uint64_t>(data[3]) << 8) | static_cast<std::uint64_t>(data[2]);
+
+    std::array<std::uint8_t, 16> values;
+    for (unsigned int i = 0; i < 16; ++i, x >>= 3) {
+        values[i] = palette[x & 7];
+    }
+    return values;
+}
+
+template <typename OutputT>
+void copy_block(gsl::span<OutputT> pixels, unsigned long width, unsigned long height,
+                unsigned long x, unsigned long y, const std::array<ColorSRGBA, 16>& values)
+{
+    auto num_rows = std::min(4LU, height - y);
+    auto num_cols = std::min(4LU, width - x);
+    auto dest_it  = pixels.begin() + y * width + x;
+    auto src_it   = values.begin();
+    for (auto row = 0LU; row < num_rows; ++row, src_it += 4, dest_it += width) {
+        std::transform(src_it, src_it + num_cols, dest_it, [](const ColorSRGBA& c) {
+            return ColorTraits<OutputT>::from_r8g8b8a8(c.r, c.g, c.b, c.a);
+        });
+    }
+}
+
+PixelFormat to_linear_space(PixelFormat format)
+{
+    switch (format) {
+    case PixelFormat::r8g8b8a8_unorm_srgb:
+        return PixelFormat::r8g8b8a8_unorm;
+    case PixelFormat::b8g8r8a8_unorm_srgb:
+        return PixelFormat::b8g8r8a8_unorm;
+    case PixelFormat::bc1_unorm_srgb:
+        return PixelFormat::bc1_unorm;
+    case PixelFormat::bc2_unorm_srgb:
+        return PixelFormat::bc2_unorm;
+    case PixelFormat::bc3_unorm_srgb:
+        return PixelFormat::bc3_unorm;
+    default:
+        assert(false);
+        return format;
+    }
+}
+
+PixelFormat to_srgb_space(PixelFormat format)
+{
+    switch (format) {
+    case PixelFormat::r8g8b8a8_unorm:
+        return PixelFormat::r8g8b8a8_unorm_srgb;
+    case PixelFormat::b8g8r8a8_unorm:
+        return PixelFormat::b8g8r8a8_unorm_srgb;
+    case PixelFormat::bc1_unorm:
+        return PixelFormat::bc1_unorm_srgb;
+    case PixelFormat::bc2_unorm:
+        return PixelFormat::bc2_unorm_srgb;
+    case PixelFormat::bc3_unorm:
+        return PixelFormat::bc3_unorm_srgb;
+    default:
+        assert(false);
+        return format;
+    }
+}
+} // namespace
+
+template <typename T>
+std::vector<T> TextureDesc::pixels_generic(int subresource_index) const noexcept
+{
+    assert(subresource_index < m_subresources.size());
+    unsigned int  mip_level = subresource_index % m_mip_levels;
+    unsigned long width     = std::max(1LU, m_width >> mip_level);
+    unsigned long height    = std::max(1LU, m_height >> mip_level);
+
+    std::vector<T> pixels(width * height);
+
+    const auto& subresource = m_subresources[subresource_index];
+
+    using CT = ColorTraits<T>;
+
+    const std::uint8_t* src = m_data.data() + subresource.data_offset;
+    switch (m_pixel_format) {
+    case PixelFormat::r8g8b8a8_unorm:
+    case PixelFormat::r8g8b8a8_unorm_srgb: {
+        assert(subresource.data_size == pixels.size() * 4);
+        T* dest = pixels.data();
+        for (std::size_t i = 0; i < pixels.size(); ++i, src += 4, ++dest) {
+            *dest = CT::from_r8g8b8a8(src[0], src[1], src[2], src[3]);
+        }
+        break;
+    }
+
+    case PixelFormat::b8g8r8a8_unorm:
+    case PixelFormat::b8g8r8a8_unorm_srgb: {
+        assert(subresource.data_size == pixels.size() * 4);
+        T* dest = pixels.data();
+        for (std::size_t i = 0; i < pixels.size(); ++i, src += 4, ++dest) {
+            *dest = CT::from_r8g8b8a8(src[2], src[1], src[0], src[3]);
+        }
+        break;
+    }
+
+    case PixelFormat::bc1_unorm:
+    case PixelFormat::bc1_unorm_srgb: {
+        unsigned long block_aligned_width  = (width + 3) & -4;
+        unsigned long block_aligned_height = (height + 3) & -4;
+        assert(subresource.data_size == block_aligned_width * block_aligned_height / 2);
+
+        for (unsigned long y = 0; y < block_aligned_height; y += 4) {
+            for (unsigned long x = 0; x < block_aligned_width; x += 4, src += 8) {
+                const auto values = unpack_bc1_block(src);
+                copy_block<T>(pixels, width, height, x, y, values);
+            }
+        }
+        break;
+    }
+
+    case PixelFormat::bc2_unorm:
+    case PixelFormat::bc2_unorm_srgb: {
+        unsigned long block_aligned_width  = (width + 3) & -4;
+        unsigned long block_aligned_height = (height + 3) & -4;
+        assert(subresource.data_size == block_aligned_width * block_aligned_height);
+
+        for (unsigned long y = 0; y < block_aligned_height; y += 4) {
+            for (unsigned long x = 0; x < block_aligned_width; x += 4, src += 16) {
+                const auto alpha  = unpack_bc2_alpha(src);
+                const auto values = unpack_bc1_block(src + 8, alpha);
+                copy_block<T>(pixels, width, height, x, y, values);
+            }
+        }
+        break;
+    }
+
+    case PixelFormat::bc3_unorm:
+    case PixelFormat::bc3_unorm_srgb: {
+        unsigned long block_aligned_width  = (width + 3) & -4;
+        unsigned long block_aligned_height = (height + 3) & -4;
+        assert(subresource.data_size == block_aligned_width * block_aligned_height);
+
+        for (unsigned long y = 0; y < block_aligned_height; y += 4) {
+            for (unsigned long x = 0; x < block_aligned_width; x += 4, src += 16) {
+                const auto alpha  = unpack_bc4_block(src);
+                const auto values = unpack_bc1_block(src + 8, alpha);
+                copy_block<T>(pixels, width, height, x, y, values);
+            }
+        }
+        break;
+    }
+    }
+    return pixels;
+}
+
+std::vector<ColorRGBA> TextureDesc::pixels_linear(int subresource_index) const noexcept
+{
+    auto pixels = pixels_generic<ColorRGBA>(subresource_index);
+    if (color_space(m_pixel_format) == ColorSpace::srgb) {
+        // Convert to linear
+        for (auto& pixel : pixels) {
+            pixel = ColorRGBA(ColorSRGBA(pixel.r, pixel.g, pixel.b, pixel.a));
+        }
+    }
+    return pixels;
+}
+
+std::vector<ColorSRGBA> TextureDesc::pixels_srgb(int subresource_index) const noexcept
+{
+    auto pixels = pixels_generic<ColorSRGBA>(subresource_index);
+    if (color_space(m_pixel_format) == ColorSpace::linear) {
+        // Convert to sRGBA
+        for (auto& pixel : pixels) {
+            pixel = ColorSRGBA(ColorRGBA(pixel.r, pixel.g, pixel.b, pixel.a));
+        }
+    }
+    return pixels;
+}
+
+ColorSpace color_space(PixelFormat format)
+{
+    switch (format) {
+    case PixelFormat::r8g8b8a8_unorm:
+    case PixelFormat::b8g8r8a8_unorm:
+    case PixelFormat::bc1_unorm:
+    case PixelFormat::bc2_unorm:
+    case PixelFormat::bc3_unorm:
+        return ColorSpace::linear;
+
+    case PixelFormat::r8g8b8a8_unorm_srgb:
+    case PixelFormat::b8g8r8a8_unorm_srgb:
+    case PixelFormat::bc1_unorm_srgb:
+    case PixelFormat::bc2_unorm_srgb:
+    case PixelFormat::bc3_unorm_srgb:
+        return ColorSpace::srgb;
+
+    default:
+        assert(false);
+        return ColorSpace::srgb;
+    }
+}
+
+PixelFormat to_color_space(PixelFormat format, ColorSpace color_space)
+{
+    switch (color_space) {
+    case ColorSpace::linear:
+        return to_linear_space(format);
+    case ColorSpace::srgb:
+        return to_srgb_space(format);
+    default:
+        assert(false);
+        return to_srgb_space(format);
+    }
+}
+
+} // namespace khepri::renderer

--- a/openglyph/src/assets/asset_cache.cpp
+++ b/openglyph/src/assets/asset_cache.cpp
@@ -32,7 +32,11 @@ auto create_texture_loader(AssetLoader& asset_loader, khepri::renderer::Renderer
 {
     return [&](std::string_view name) -> std::unique_ptr<khepri::renderer::Texture> {
         if (auto stream = asset_loader.open_texture(name)) {
-            auto texture_desc = khepri::renderer::io::load_texture(*stream);
+            // Older games that do not support extended pixel format information are generally read
+            // in linear space, because their graphics APIs (e.g. DX9) lacked the notion of sRGB
+            // textures.
+            auto texture_desc =
+                khepri::renderer::io::load_texture(*stream, {khepri::renderer::ColorSpace::linear});
             return renderer.create_texture(texture_desc);
         }
         return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,9 +192,15 @@ int main(int argc, const char* argv[])
 
         openglyph::AssetLoader asset_loader(std::move(data_paths));
 
-        khepri::application::Window          window(APPLICATION_NAME);
-        khepri::renderer::diligent::Renderer renderer(window.native_handle());
-        khepri::renderer::Camera             camera = create_camera(window.render_size());
+        khepri::application::Window window(APPLICATION_NAME);
+
+        // Note: Empire at War was written for DX9 and does not natively support sRGB mode. Textures
+        // are read & modified in linear space and (roughly) gamma-corrected in the shader. Thus,
+        // the output format should be in linear space.
+        khepri::renderer::diligent::Renderer renderer(window.native_handle(),
+                                                      khepri::renderer::ColorSpace::linear);
+
+        khepri::renderer::Camera camera = create_camera(window.render_size());
         window.add_size_listener([&] {
             const auto render_size = window.render_size();
             renderer.render_size(render_size);


### PR DESCRIPTION
Normals maps were, like all other textures, read in sRGB space. This is wrong, as normal maps should not be gamma corrected when sampled: this produces incorrect lighting results.

Attempts to identify normal maps so they could be loaded in linear space are not feasible; they either rely on manually-maintained (and thus error-prone) filename lists, or rely on (flaky) content detection.

Instead, the entire pipeline was switched to linear space: all textures are read in linear space, and the output format is in linear space, too.
This also better matches the original Empire at War graphics pipeline: it used DirectX9, which didn't support sRGB space for textures or render targets. Shaders were expected to do the conversion, if at all.

With this change, shaders are not responsible for gamma. This requires and explains the x2 output factor present in the original EaW shaders that was used in placed. Without it, the image is too dark due to the (lack of) gamma conversion.

Note: some texture-unpacking code is part of this change, as it was used in an earlier iteration. It is now unused, but could still be useful in the future.

Closes #71.