### PR TITLE
feat: add additional materials

### DIFF
--- a/data-extra/Data/Art/Shaders/MeshAdditive.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshAdditive.hlsl
@@ -4,8 +4,8 @@
 // Material
 cbuffer Material
 {
-	float3 Color;
-	float2 UVScrollRate;
+    float3 Color;
+    float2 UVScrollRate;
 };
 
 Texture2D BaseTexture;
@@ -15,30 +15,30 @@ SamplerState BaseTextureSampler;
 
 struct VS_INPUT_MESH
 {
-	float3 Pos : ATTRIB0;
-	float2 UV : ATTRIB4;
+    float3 Pos : ATTRIB0;
+    float2 UV : ATTRIB4;
 };
 
 struct VS_OUTPUT
 {
-	float4 Pos : SV_Position; // Position (camera space)
-	float2 UV : TEXCOORD1; // Texture coordinates (tangent space)
-	float4 Diffuse: COLOR0;
+    float4 Pos : SV_Position; // Position (camera space)
+    float2 UV : TEXCOORD1; // Texture coordinates (tangent space)
+    float4 Diffuse: COLOR0;
 };
 
 VS_OUTPUT vs_main(VS_INPUT_MESH In)
 {
-	VS_OUTPUT Out;
+    VS_OUTPUT Out;
 
-	Out.Pos = mul(float4(In.Pos, 1), mul(World, ViewProj));
-	Out.UV = In.UV;
-	Out.Diffuse = float4(Color, 1);
+    Out.Pos = mul(float4(In.Pos, 1), mul(World, ViewProj));
+    Out.UV = In.UV;
+    Out.Diffuse = float4(Color, 1);
 
-	return Out;
+    return Out;
 }
 
 float4 ps_main(VS_OUTPUT In) : SV_Target
 {
-	float4 texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
-	return texel * In.Diffuse;
+    float4 texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
+    return texel * In.Diffuse;
 }

--- a/data-extra/Data/Art/Shaders/MeshAdditiveVColor.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshAdditiveVColor.hlsl
@@ -4,7 +4,7 @@
 // Material
 cbuffer Material
 {
-	float2 UVScrollRate;
+    float2 UVScrollRate;
 };
 
 Texture2D BaseTexture;
@@ -14,31 +14,31 @@ SamplerState BaseTextureSampler;
 
 struct VS_INPUT_MESH
 {
-	float3 Pos : ATTRIB0;
-	float2 UV : ATTRIB4;
-	float3 Color : ATTRIB5;
+    float3 Pos : ATTRIB0;
+    float2 UV : ATTRIB4;
+    float3 Color : ATTRIB5;
 };
 
 struct VS_OUTPUT
 {
-	float4 Pos : SV_Position; // Position (camera space)
-	float2 UV : TEXCOORD1; // Texture coordinates (tangent space)
-	float4 Diffuse: COLOR0;
+    float4 Pos : SV_Position; // Position (camera space)
+    float2 UV : TEXCOORD1; // Texture coordinates (tangent space)
+    float4 Diffuse: COLOR0;
 };
 
 VS_OUTPUT vs_main(VS_INPUT_MESH In)
 {
-	VS_OUTPUT Out;
+    VS_OUTPUT Out;
 
-	Out.Pos = mul(float4(In.Pos, 1), mul(World, ViewProj));
-	Out.UV = In.UV;
-	Out.Diffuse = float4(In.Color, 1);
+    Out.Pos = mul(float4(In.Pos, 1), mul(World, ViewProj));
+    Out.UV = In.UV;
+    Out.Diffuse = float4(In.Color, 1);
 
-	return Out;
+    return Out;
 }
 
 float4 ps_main(VS_OUTPUT In) : SV_Target
 {
-	float4 texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
-	return texel * In.Diffuse;
+    float4 texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
+    return texel * In.Diffuse;
 }

--- a/data-extra/Data/Art/Shaders/MeshAlpha.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshAlpha.hlsl
@@ -5,7 +5,7 @@
 cbuffer Material
 {
     float3 Emissive;
-    float3 Diffuse;
+    float4 Diffuse;
     float3 Specular;
 };
 
@@ -25,9 +25,10 @@ struct VS_OUTPUT
 {
     float4 Pos : SV_Position; // Position (camera space)
     float2 UV : TEXCOORD1; // Texture coordinates (tangent space)
-    float3 Diffuse: COLOR0;
+    float4 Diffuse: COLOR0;
     float3 Spec: COLOR1;
 };
+
 
 VS_OUTPUT vs_main(VS_INPUT_MESH In)
 {
@@ -47,7 +48,7 @@ VS_OUTPUT vs_main(VS_INPUT_MESH In)
 
     Out.Pos = mul(world_pos, ViewProj);
     Out.UV = In.UV;
-    Out.Diffuse = Diffuse * diff_light + Emissive;
+    Out.Diffuse = float4(Diffuse.rgb * diff_light + Emissive, Diffuse.a);
     Out.Spec = Specular * DirectionalLights[0].intensity * DirectionalLights[0].specular_color * pow(max(0, dot(world_normal, light_half_vec)), 16);
     return Out;
 }
@@ -55,7 +56,6 @@ VS_OUTPUT vs_main(VS_INPUT_MESH In)
 float4 ps_main(VS_OUTPUT In) : SV_Target
 {
     float4 base_texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
-    float3 diffuse = In.Diffuse * base_texel.rgb * 2;
-    float3 specular = In.Spec * base_texel.a;
-    return float4(diffuse + specular, 1);
+    float4 diffuse = base_texel * In.Diffuse;
+    return float4(diffuse.rgb * 2 + In.Spec.rgb, diffuse.a);
 }

--- a/data-extra/Data/Art/Shaders/MeshBumpColorize.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshBumpColorize.hlsl
@@ -4,11 +4,11 @@
 // Material
 cbuffer Material
 {
-	float3 Emissive;
-	float3 Diffuse;
-	float3 Specular;
-	float3 Colorization;
-	float2 UVOffset;
+    float3 Emissive;
+    float3 Diffuse;
+    float3 Specular;
+    float3 Colorization;
+    float2 UVOffset;
 };
 
 Texture2D BaseTexture;
@@ -21,20 +21,20 @@ SamplerState NormalTextureSampler;
 
 struct VS_INPUT_MESH
 {
-	float3 Pos : ATTRIB0;
-	float3 Normal : ATTRIB1;
-	float3 Tangent : ATTRIB2;
-	float3 Binormal : ATTRIB3;
-	float2 UV : ATTRIB4;
+    float3 Pos : ATTRIB0;
+    float3 Normal : ATTRIB1;
+    float3 Tangent : ATTRIB2;
+    float3 Binormal : ATTRIB3;
+    float2 UV : ATTRIB4;
 };
 
 struct VS_OUTPUT
 {
-	float4 Pos : SV_Position; // Position (camera space)
-	float2 UV : TEXCOORD0; // Texture coordinates (tangent space)
-	float3 LightDir : TEXCOORD1; // Light direction (tangent space)
-	float3 HalfAngleVector: TEXCOORD2; // Half Angle light vector (tangent space)
-	float3 Diff : COLOR0; // Per-vertex diffuse color
+    float4 Pos : SV_Position; // Position (camera space)
+    float2 UV : TEXCOORD0; // Texture coordinates (tangent space)
+    float3 LightDir : TEXCOORD1; // Light direction (tangent space)
+    float3 HalfAngleVector: TEXCOORD2; // Half Angle light vector (tangent space)
+    float3 Diff : COLOR0; // Per-vertex diffuse color
 };
 
 VS_OUTPUT vs_main(VS_INPUT_MESH In)
@@ -45,44 +45,44 @@ VS_OUTPUT vs_main(VS_INPUT_MESH In)
     VS_OUTPUT Out;
     Out.Pos = mul(world_pos, ViewProj);
 
-	// Store the light direction in tangent space
-	float3x3 local_to_tangent = to_tangent_matrix(In.Tangent,In.Binormal,In.Normal);
-	float3x3 world_to_tangent = mul((float3x3)WorldInv, local_to_tangent);
+    // Store the light direction in tangent space
+    float3x3 local_to_tangent = to_tangent_matrix(In.Tangent,In.Binormal,In.Normal);
+    float3x3 world_to_tangent = mul((float3x3)WorldInv, local_to_tangent);
 
-	float3 light0_dir = normalize(mul(-DirectionalLights[0].direction, world_to_tangent));
-	float3 light1_dir = normalize(mul(-DirectionalLights[1].direction, world_to_tangent));
-	float3 light2_dir = normalize(mul(-DirectionalLights[2].direction, world_to_tangent));
+    float3 light0_dir = normalize(mul(-DirectionalLights[0].direction, world_to_tangent));
+    float3 light1_dir = normalize(mul(-DirectionalLights[1].direction, world_to_tangent));
+    float3 light2_dir = normalize(mul(-DirectionalLights[2].direction, world_to_tangent));
 
-	// Main light is calculated in pixel shader; pass light vector. Other lights are calculated per-vertex.
-	// Note that the light directions are in tangent space, so dot(N,L) is just L.z, since the normal vector
-	// is always 0,0,1 in tangent space.
-	Out.LightDir = encode_vector(light0_dir);
-	Out.Diff = Diffuse.rgb *
-	           (DirectionalLights[1].intensity * DirectionalLights[1].diffuse_color * saturate(light1_dir.z) +
-	            DirectionalLights[2].intensity * DirectionalLights[2].diffuse_color * saturate(light2_dir.z)) +
-			   Emissive;
+    // Main light is calculated in pixel shader; pass light vector. Other lights are calculated per-vertex.
+    // Note that the light directions are in tangent space, so dot(N,L) is just L.z, since the normal vector
+    // is always 0,0,1 in tangent space.
+    Out.LightDir = encode_vector(light0_dir);
+    Out.Diff = Diffuse.rgb *
+               (DirectionalLights[1].intensity * DirectionalLights[1].diffuse_color * saturate(light1_dir.z) +
+                DirectionalLights[2].intensity * DirectionalLights[2].diffuse_color * saturate(light2_dir.z)) +
+               Emissive;
 
-	Out.HalfAngleVector = encode_vector(normalize(mul(light_half_angle((float3)world_pos, camera_pos, -DirectionalLights[0].direction), world_to_tangent)));
+    Out.HalfAngleVector = encode_vector(normalize(mul(light_half_angle((float3)world_pos, camera_pos, -DirectionalLights[0].direction), world_to_tangent)));
 
-	Out.UV = In.UV + UVOffset;
+    Out.UV = In.UV + UVOffset;
     return Out;
 }
 
 float4 ps_main(VS_OUTPUT In) : SV_Target
 {
-	float4 base_texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
-	float4 normal_texel = NormalTexture.Sample(NormalTextureSampler, In.UV);
+    float4 base_texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
+    float4 normal_texel = NormalTexture.Sample(NormalTextureSampler, In.UV);
 
-	// base_texel alpha contains colorization channel
-	float3 surface_color = lerp(base_texel.rgb, Colorization * base_texel.rgb, base_texel.a);
+    // base_texel alpha contains colorization channel
+    float3 surface_color = lerp(base_texel.rgb, Colorization * base_texel.rgb, base_texel.a);
 
-	// Normal vector and light direction (both in tangent space)
-	float3 normal = decode_vector(normal_texel.rgb);
-	float3 light_dir = decode_vector(In.LightDir);
-	float3 half_vec = decode_vector(In.HalfAngleVector);
+    // Normal vector and light direction (both in tangent space)
+    float3 normal = decode_vector(normal_texel.rgb);
+    float3 light_dir = decode_vector(In.LightDir);
+    float3 half_vec = decode_vector(In.HalfAngleVector);
 
-	// Calculate main light in pixel shader to use normal map
-	float3 diffuse = surface_color * (In.Diff + DirectionalLights[0].intensity * DirectionalLights[0].diffuse_color * saturate(dot(normal, light_dir))) * 2;
-	float3 spec = normal_texel.a * Specular * DirectionalLights[0].intensity * DirectionalLights[0].specular_color * pow(saturate(dot(normal, half_vec)), 16);
-	return float4(diffuse + spec, 1);
+    // Calculate main light in pixel shader to use normal map
+    float3 diffuse = surface_color * (In.Diff + DirectionalLights[0].intensity * DirectionalLights[0].diffuse_color * saturate(dot(normal, light_dir))) * 2;
+    float3 spec = normal_texel.a * Specular * DirectionalLights[0].intensity * DirectionalLights[0].specular_color * pow(saturate(dot(normal, half_vec)), 16);
+    return float4(diffuse + spec, 1);
 }

--- a/data-extra/Data/Art/Shaders/MeshGlossColorize.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshGlossColorize.hlsl
@@ -7,10 +7,14 @@ cbuffer Material
     float3 Emissive;
     float3 Diffuse;
     float3 Specular;
+    float3 Colorization;
 };
 
 Texture2D BaseTexture;
 SamplerState BaseTextureSampler;
+
+Texture2D GlossTexture;
+SamplerState GlossTextureSampler;
 
 ////////////////////////////////////////////////
 
@@ -55,7 +59,10 @@ VS_OUTPUT vs_main(VS_INPUT_MESH In)
 float4 ps_main(VS_OUTPUT In) : SV_Target
 {
     float4 base_texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
-    float3 diffuse = In.Diffuse * base_texel.rgb * 2;
-    float3 specular = In.Spec * base_texel.a;
+    float4 gloss_texel = GlossTexture.Sample(GlossTextureSampler, In.UV);
+
+    float3 surface_color = lerp(base_texel.rgb, Colorization * base_texel.rgb, base_texel.a);
+    float3 diffuse = In.Diffuse.rgb * surface_color * 2;
+    float3 specular = In.Spec * gloss_texel.r;
     return float4(diffuse + specular, 1);
 }

--- a/data-extra/Data/Art/Shaders/MeshSolidColor.hlsl
+++ b/data-extra/Data/Art/Shaders/MeshSolidColor.hlsl
@@ -1,0 +1,32 @@
+#include "common.hlsli"
+
+////////////////////////////////////////////////
+// Material
+cbuffer Material
+{
+    float4 Color;
+};
+
+struct VS_INPUT_MESH
+{
+    float3 Pos : ATTRIB0;
+};
+
+struct VS_OUTPUT
+{
+    float4 Pos : SV_Position; // Position (camera space)
+    float4 Diffuse: COLOR0;
+};
+
+VS_OUTPUT vs_main(VS_INPUT_MESH In)
+{
+    VS_OUTPUT Out;
+    Out.Pos  = mul(float4(In.Pos, 1), mul(World, ViewProj));
+    Out.Diffuse = Color;
+    return Out;
+}
+
+float4 ps_main(VS_OUTPUT In) : SV_Target
+{
+    return In.Diffuse;
+}

--- a/data-extra/Data/Art/Shaders/Nebula.hlsl
+++ b/data-extra/Data/Art/Shaders/Nebula.hlsl
@@ -1,0 +1,67 @@
+#include "common.hlsli"
+
+////////////////////////////////////////////////
+// Material
+cbuffer Material
+{
+    float DistortionScale;
+    float SFreq;
+    float TFreq;
+    float2 UVScrollRate;
+};
+
+Texture2D BaseTexture;
+SamplerState BaseTextureSampler;
+
+////////////////////////////////////////////////
+
+struct VS_INPUT_MESH
+{
+    float3 Pos : ATTRIB0;
+    float3 Normal : ATTRIB1;
+    float2 UV : ATTRIB4;
+    float3 Color : ATTRIB5;
+};
+
+struct VS_OUTPUT
+{
+    float4 Pos : SV_Position; // Position (camera space)
+    float2 UV : TEXCOORD1; // Texture coordinates (tangent space)
+    float4 Diffuse: COLOR0;
+};
+
+VS_OUTPUT vs_main(VS_INPUT_MESH In)
+{
+    VS_OUTPUT Out;
+
+    float3 world_pos = mul(float4(In.Pos,1), World).xyz;
+
+    float SPATIAL_FREQ = SFreq;
+    float TIME_FREQ = TFreq;
+    float SCALE = DistortionScale;
+    float Time = 0;
+
+    float3 offset = float3(
+        sin(2*PI * frac(SPATIAL_FREQ * world_pos.x + TIME_FREQ * Time) ),
+        sin(2*PI * frac(SPATIAL_FREQ * world_pos.y + TIME_FREQ * Time) ),
+        sin(2*PI * frac(SPATIAL_FREQ * world_pos.z + TIME_FREQ * Time) ));
+
+    float3 obj_pos = In.Pos + SCALE * offset;
+
+    // Edge fade
+    float3 view_normal = normalize(mul(In.Normal, (float3x3)mul(World, View)));
+    float scale = offset.x;
+    float edge = 0.9 * view_normal.z + 0.1 * scale;
+    float edge_fade = pow(view_normal.z, 8) * 2 + 0.1;
+
+    Out.Pos     = mul(float4(obj_pos, 1), mul(World, ViewProj));
+    Out.UV      = In.UV + Time * UVScrollRate * 3;
+    Out.Diffuse = float4(In.Color.rgb, 1) * edge_fade;
+    return Out;
+}
+
+float4 ps_main(VS_OUTPUT In) : SV_Target
+{
+    float4 texel = BaseTexture.Sample(BaseTextureSampler, In.UV);
+    return texel * In.Diffuse;
+}

--- a/data-extra/Data/Art/Shaders/Planet.hlsl
+++ b/data-extra/Data/Art/Shaders/Planet.hlsl
@@ -1,0 +1,127 @@
+#include "common.hlsli"
+
+////////////////////////////////////////////////
+// Material
+cbuffer Material
+{
+    float3 Emissive;
+    float3 Diffuse;
+    float3 Specular;
+    float4 Atmosphere;
+    float3 CityColor;
+    float AtmospherePower;
+    float CloudScrollRate;
+};
+
+Texture2D BaseTexture;
+SamplerState BaseTextureSampler;
+
+Texture2D NormalTexture;
+SamplerState NormalTextureSampler;
+
+Texture2D CloudTexture;
+SamplerState CloudTextureSampler;
+
+Texture2D CloudNormalTexture;
+SamplerState CloudNormalTextureSampler;
+
+
+////////////////////////////////////////////////
+
+struct VS_INPUT_MESH
+{
+    float3 Pos : ATTRIB0;
+    float3 Normal : ATTRIB1;
+    float3 Tangent : ATTRIB2;
+    float3 Binormal : ATTRIB3;
+    float2 UV : ATTRIB4;
+};
+
+struct VS_OUTPUT
+{
+    float4  Pos : SV_Position;            // Position (camera space)
+    float3  Diff : COLOR0;
+    float2  Tex0 : TEXCOORD0;             // Base + normal texture coordinates (tangent space)
+    float2  Tex1 : TEXCOORD2;             // Clouds texture coordinates (tangent space)
+    float3  LightDir : TEXCOORD3;         // Light direction (tangent space)
+    float3  HalfAngleVector: TEXCOORD4;   // Half Angle light vector (tangent space)
+    float   AtmosphereFactor : TEXCOORD5; // X = atmosphere (edge/rim factor)
+};
+
+VS_OUTPUT vs_main(VS_INPUT_MESH In)
+{
+    float Time = 0;
+
+    float4 world_pos = mul(float4(In.Pos, 1), World);
+    float3 camera_pos = camera_position();
+
+    VS_OUTPUT Out;
+    Out.Pos = mul(world_pos, ViewProj);
+
+    // Base and normal texture coords
+    Out.Tex0 = In.UV;
+
+    // Cloud texture coords: scroll along the u axis
+    Out.Tex1 = In.UV;
+    Out.Tex1.x += Time * CloudScrollRate;
+
+    // Compute the tangent-space light vector and half-angle vector for per-pixel lighting
+    // Note that we are doing everything in object space here.
+    float3x3 local_to_tangent = to_tangent_matrix(In.Tangent, In.Binormal, In.Normal);
+    float3x3 world_to_tangent = mul((float3x3)WorldInv, local_to_tangent);
+
+    float3 light0_dir = normalize(mul(-DirectionalLights[0].direction, world_to_tangent));
+    float3 light1_dir = normalize(mul(-DirectionalLights[1].direction, world_to_tangent));
+    float3 light2_dir = normalize(mul(-DirectionalLights[2].direction, world_to_tangent));
+
+    // Main light is calculated in pixel shader; pass light vector. Other lights are calculated per-vertex.
+    // Note that the light directions are in tangent space, so dot(N,L) is just L.z, since the normal vector
+    // is always 0,0,1 in tangent space.
+    Out.LightDir = encode_vector(light0_dir);
+    Out.Diff = Diffuse *
+               (DirectionalLights[1].intensity * DirectionalLights[1].diffuse_color * saturate(light1_dir.z) +
+                DirectionalLights[2].intensity * DirectionalLights[2].diffuse_color * saturate(light2_dir.z)) +
+               Emissive;
+
+    Out.HalfAngleVector = encode_vector(normalize(mul(light_half_angle(world_pos.xyz, camera_pos, -DirectionalLights[0].direction), world_to_tangent)));
+
+    // Compute the atmospheric fogging factor
+    float3 world_eye_vec = normalize(camera_pos - world_pos.xyz);
+    float3 world_normal = normalize(mul(In.Normal, (float3x3)World));
+    float vdotn = saturate(dot(world_normal, world_eye_vec));
+    Out.AtmosphereFactor = pow(1 - vdotn, AtmospherePower) * 2 * Atmosphere.a;
+
+    return Out;
+}
+
+float4 ps_main(VS_OUTPUT In) : SV_Target
+{
+    float4 base_texel = BaseTexture.Sample(BaseTextureSampler, In.Tex0);
+    float4 normal_texel = NormalTexture.Sample(NormalTextureSampler, In.Tex0);
+    float4 cloud_texel = CloudTexture.Sample(CloudTextureSampler, In.Tex1);
+    float4 cloud_normal_texel = CloudNormalTexture.Sample(CloudNormalTextureSampler, In.Tex1);
+
+    float3 normal = decode_vector(normal_texel.rgb);
+    float3 cloud_normal = decode_vector(cloud_normal_texel.rgb);
+    float3 light_dir = decode_vector(In.LightDir);
+    float3 half_vec = decode_vector(In.HalfAngleVector);
+
+    // planet color depends on the base texture and the atmosphere
+    float3 planet_color = base_texel.rgb;
+    float3 surface_color = planet_color + Atmosphere.rgb * In.AtmosphereFactor;
+
+    // Compute Lighting
+    float3 diffuse = surface_color * (In.Diff + Diffuse * DirectionalLights[0].intensity * DirectionalLights[0].diffuse_color * saturate(dot(normal, light_dir))) * 2;
+    float3 cloud_diffuse = (In.Diff + cloud_texel.rgb * DirectionalLights[0].intensity * DirectionalLights[0].diffuse_color * saturate(dot(cloud_normal, light_dir))) * 2;
+
+    // Specular lights. Normal.a indicates water.
+    float3 spec = Specular * normal_texel.a * DirectionalLights[0].intensity * DirectionalLights[0].specular_color * pow(saturate(dot(normal, half_vec)), 16);
+
+    // Add in city lights. base_texel.a indicates where cities are.
+    // When the light points away from the surface normal, it's in darkness, so we want full city lights
+    // Scale by 32 for a hard transition where the dark side of the planet starts.
+    float darkness_factor = saturate(-32 * light_dir.z);
+    diffuse += base_texel.a * darkness_factor * (1 - cloud_texel.a) * CityColor;
+
+    return float4(lerp(diffuse + spec, cloud_diffuse, cloud_texel.a), 1);
+}

--- a/data-extra/Data/Art/Shaders/common.hlsli
+++ b/data-extra/Data/Art/Shaders/common.hlsli
@@ -23,6 +23,8 @@ cbuffer InstanceConstants
 
 cbuffer ViewConstants
 {
+    float4x4 View;
+
     // mul(View, Projection)
     float4x4 ViewProj;
 
@@ -44,9 +46,11 @@ cbuffer EnvironmentConstants
 
     int NumPointLights;
 
-	// In-world time, in seconds
+    // In-world time, in seconds
     float Time;
 };
+
+static const float PI = 3.14159265;
 
 // Returns the camera position, in world space
 float3 camera_position() {

--- a/data-extra/Data/XML/Materials.xml
+++ b/data-extra/Data/XML/Materials.xml
@@ -18,6 +18,25 @@
     </Material>
     -->
 
+    <Material Name="MeshAlpha" Type="Transparent">
+        <Shader>MeshAlpha</Shader>
+        <Num_Directional_Lights>3</Num_Directional_Lights>
+        <Param Name="Emissive" Type="float3">0, 0, 0</Param>
+        <Param Name="Diffuse" Type="float4">1, 1, 1, 1</Param>
+        <Param Name="Specular" Type="float3">1, 1, 1</Param>
+        <Param Name="BaseTexture" Type="texture"></Param>
+    </Material>
+
+    <Material Name="MeshAlphaGloss" Type="Transparent">
+        <Shader>MeshAlphaGloss</Shader>
+        <Num_Directional_Lights>3</Num_Directional_Lights>
+        <Param Name="Emissive" Type="float3">0, 0, 0</Param>
+        <Param Name="Diffuse" Type="float4">1, 1, 1, 1</Param>
+        <Param Name="Specular" Type="float3">1, 1, 1</Param>
+        <Param Name="BaseTexture" Type="texture"></Param>
+        <Param Name="GlossTexture" Type="texture"></Param>
+    </Material>
+
     <Material Name="MeshBumpColorize" Type="Opaque">
         <Shader>MeshBumpColorize</Shader>
         <Num_Directional_Lights>3</Num_Directional_Lights>
@@ -39,6 +58,17 @@
         <Param Name="BaseTexture" Type="texture"></Param>
     </Material>
 
+    <Material Name="MeshGlossColorize" Type="Opaque">
+        <Shader>MeshGlossColorize</Shader>
+        <Num_Directional_Lights>3</Num_Directional_Lights>
+        <Param Name="Emissive" Type="float3">0, 0, 0</Param>
+        <Param Name="Diffuse" Type="float3">1, 1, 1</Param>
+        <Param Name="Specular" Type="float3">0, 0, 0</Param>
+        <Param Name="Colorization" Type="float3">0, 1, 0</Param>
+        <Param Name="BaseTexture" Type="texture"></Param>
+        <Param Name="GlossTexture" Type="texture"></Param>
+    </Material>
+
     <Material Name="MeshAdditive" Type="Transparent">
         <Shader>MeshAdditive</Shader>
         <Num_Directional_Lights>0</Num_Directional_Lights>
@@ -52,5 +82,37 @@
         <Num_Directional_Lights>0</Num_Directional_Lights>
         <Param Name="UVScrollRate" Type="float2">0, 0</Param>
         <Param Name="BaseTexture" Type="texture"></Param>
+    </Material>
+
+    <Material Name="MeshSolidColor" Type="Opaque">
+        <Shader>MeshSolidColor</Shader>
+        <Num_Directional_Lights>0</Num_Directional_Lights>
+        <Param Name="Color" Type="float4">0, 0, 1, 0.5</Param>
+    </Material>
+
+    <Material Name="Nebula" Type="Transparent">
+        <Shader>Nebula</Shader>
+        <Num_Directional_Lights>0</Num_Directional_Lights>
+        <Param Name="DistortionScale" Type="float">25.0f</Param>
+        <Param Name="SFreq" Type="float">0.002f</Param>
+        <Param Name="TFreq" Type="float">0.05f</Param>
+        <Param Name="UVScrollRate" Type="float2">0, 0</Param>
+        <Param Name="BaseTexture" Type="texture"></Param>
+    </Material>
+
+    <Material Name="Planet" Type="Opaque">
+        <Shader>Planet</Shader>
+        <Num_Directional_Lights>3</Num_Directional_Lights>
+        <Param Name="Emissive" Type="float3">0, 0, 0</Param>
+        <Param Name="Diffuse" Type="float3">1, 1, 1</Param>
+        <Param Name="Specular" Type="float3">1, 1, 1</Param>
+        <Param Name="Atmosphere" Type="float4">0, 0, 0, 1</Param>
+        <Param Name="CityColor" Type="float3">1, 1, 1</Param>
+        <Param Name="AtmospherePower" Type="float">4.5</Param>
+        <Param Name="CloudScrollRate" Type="float">0.0025</Param>
+        <Param Name="BaseTexture" Type="texture"></Param>
+        <Param Name="NormalTexture" Type="texture"></Param>
+        <Param Name="CloudTexture" Type="texture"></Param>
+        <Param Name="CloudNormalTexture" Type="texture"></Param>
     </Material>
 </Materials>

--- a/khepri/src/renderer/diligent/renderer.cpp
+++ b/khepri/src/renderer/diligent/renderer.cpp
@@ -50,10 +50,11 @@ static_assert(sizeof(InstanceConstantBuffer) == 8 * 16); // Validate packing
 
 struct ViewConstantBuffer
 {
+    Matrixf view;
     Matrixf view_proj;
     Matrixf view_proj_inv;
 };
-static_assert(sizeof(ViewConstantBuffer) == 8 * 16); // Validate packing
+static_assert(sizeof(ViewConstantBuffer) == 12 * 16); // Validate packing
 
 struct DirectionalLight
 {
@@ -980,6 +981,7 @@ public:
         {
             MapHelper<ViewConstantBuffer> constants(m_context, m_constants.view, MAP_WRITE,
                                                     MAP_FLAG_DISCARD);
+            constants->view          = camera_matrices.view;
             constants->view_proj     = camera_matrices.view_proj;
             constants->view_proj_inv = camera_matrices.view_proj_inv;
         }


### PR DESCRIPTION
This change adds several materials that have been missing, allowing more objects to be rendered:

MeshAlpha, MeshAlphaGloss, MeshGloss, MeshGlossColorize, MeshSolidColor, Nebula and Planet

The "view" matrix also had to be exported to shaders for the Nebula shader to work.