### PR TITLE
fix: alpha-blended materialsare rendered as additive

### DIFF
--- a/data-extra/Data/XML/Materials.xml
+++ b/data-extra/Data/XML/Materials.xml
@@ -75,6 +75,9 @@
         <Param Name="Color" Type="float3">1, 0, 1</Param>
         <Param Name="UVScrollRate" Type="float2">0, 0</Param>
         <Param Name="BaseTexture" Type="texture"></Param>
+
+        <!-- Override default pipeline properties -->
+        <Alpha_Blend>additive</Alpha_Blend>
     </Material>
 
     <Material Name="MeshAdditiveVColor" Type="Transparent">
@@ -82,6 +85,9 @@
         <Num_Directional_Lights>0</Num_Directional_Lights>
         <Param Name="UVScrollRate" Type="float2">0, 0</Param>
         <Param Name="BaseTexture" Type="texture"></Param>
+
+        <!-- Override default pipeline properties -->
+        <Alpha_Blend>additive</Alpha_Blend>
     </Material>
 
     <Material Name="MeshSolidColor" Type="Opaque">
@@ -98,6 +104,9 @@
         <Param Name="TFreq" Type="float">0.05f</Param>
         <Param Name="UVScrollRate" Type="float2">0, 0</Param>
         <Param Name="BaseTexture" Type="texture"></Param>
+
+        <!-- Override default pipeline properties -->
+        <Alpha_Blend>additive</Alpha_Blend>
     </Material>
 
     <Material Name="Planet" Type="Opaque">

--- a/data-extra/Data/XML/RenderPipelines.xml
+++ b/data-extra/Data/XML/RenderPipelines.xml
@@ -6,8 +6,12 @@
             <Material_Type>Opaque</Material_Type>
             <!-- Sort front-to-back to minimize overdraw -->
             <Depth_Sort>front_to_back</Depth_Sort>
-            <AlphaBlend>blend_src</AlphaBlend>
-            <DepthFunc>less_equal</DepthFunc>
+
+            <!-- Default pipeline properties. Materials can override these. -->
+            <Front_CCW>true</Front_CCW>
+            <Cull_Mode>back</Cull_Mode>
+            <Alpha_Blend>blend_src</Alpha_Blend>
+            <Depth_Func>less_equal</Depth_Func>
         </RenderPass>
 
         <!-- Render phase for all transparent objects. This is rendered after the solids to allow alpha-blending effects to work -->
@@ -15,9 +19,13 @@
             <Material_Type>Transparent</Material_Type>
             <!-- Sort back-to-front to ensure alpha blending works correctly -->
             <Depth_Sort>back_to_front</Depth_Sort>
-            <AlphaBlend>additive</AlphaBlend>
-            <DepthFunc>less_equal</DepthFunc>
-            <DepthWriteEnable>false</DepthWriteEnable>
+
+            <!-- Default pipeline properties. Materials can override these. -->
+            <Front_CCW>true</Front_CCW>
+            <Cull_Mode>back</Cull_Mode>
+            <Alpha_Blend>blend_src</Alpha_Blend>
+            <Depth_Func>less_equal</Depth_Func>
+            <Depth_Write_Enable>false</Depth_Write_Enable>
         </RenderPass>
     </RenderPipeline>
 </RenderPipelines>

--- a/khepri/include/khepri/renderer/material_desc.hpp
+++ b/khepri/include/khepri/renderer/material_desc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "render_pipeline_desc.hpp"
 #include "shader.hpp"
 #include "texture.hpp"
 
@@ -70,6 +71,14 @@ struct MaterialDesc
 
     /// Shader properties of this material
     std::vector<Property> properties;
+
+    /**
+     * Graphics pipeline options for this material.
+     *
+     * This field is used as an override on the options in the #RenderPipelineDesc. See
+     * #GraphicsPipelineOptions for more information.
+     */
+    GraphicsPipelineOptions graphics_pipeline_options;
 };
 
 } // namespace khepri::renderer

--- a/khepri/include/khepri/renderer/render_pipeline_desc.hpp
+++ b/khepri/include/khepri/renderer/render_pipeline_desc.hpp
@@ -1,31 +1,23 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace khepri::renderer {
 
 /**
- * Description of a render pass in a pipeline.
+ * Options to configure the graphics pipeline with.
  *
- * A render pass renders meshes in a certain way.
+ * All properties are optional because this type is re-used by #RenderPipelineDesc and
+ * #MaterialDesc, where the latter's options can override the former's.
+ *
+ * The renderer has built-in defaults if both the render pipeline and material don't specify the
+ * option. The defaults are specified in the comments for each property.
  */
-struct RenderPassDesc
+struct GraphicsPipelineOptions
 {
-    /// How to sort objects by depth during this render pass
-    enum class DepthSorting : std::uint8_t
-    {
-        /// Objects are rendered in arbitrary order.
-        none,
-
-        /// Objects are rendered front-to-back, i.e. those closer to the camera are rendered first.
-        front_to_back,
-
-        /// Objects are rendered back-to-front, i.e. those closer to the camera are rendered last.
-        back_to_front,
-    };
-
     /// The type of face culling
     enum class CullMode : std::uint8_t
     {
@@ -60,31 +52,55 @@ struct RenderPassDesc
         additive,
     };
 
-    struct DepthBufferDesc
-    {
-        /// Depth test comparison function, if any.
-        /// Set to \a std::nullopt to disable depth testing.
-        ComparisonFunc comparison_func{ComparisonFunc::less};
+    /// Face culling mode of this render pass (default=back).
+    std::optional<CullMode> cull_mode;
 
-        /// Enable depth-buffer writing
-        bool write_enable{true};
+    /// Do front-faces have counter-clockwise winding order? If not, they have clock-wise winding
+    /// order (default=false)
+    std::optional<bool> front_ccw;
+
+    /// Type of alpha blending to use for this render pass (default=none).
+    std::optional<AlphaBlendMode> alpha_blend_mode;
+
+    /// Whether depth buffer interactions are enabled (default=true).
+    std::optional<bool> depth_enable;
+
+    /// Depth-buffer test comparison function (default=less). Ignored if \a depth_enable is false.
+    std::optional<ComparisonFunc> depth_comparison_func;
+
+    /// Whether to enable depth-buffer writing (default=true). Ignored if \a depth_enable is false.
+    std::optional<bool> depth_write_enable;
+};
+
+/**
+ * Description of a render pass in a pipeline.
+ *
+ * A render pass renders meshes in a certain way.
+ */
+struct RenderPassDesc
+{
+    /// How to sort objects by depth during this render pass
+    enum class DepthSorting : std::uint8_t
+    {
+        /// Objects are rendered in arbitrary order.
+        none,
+
+        /// Objects are rendered front-to-back, i.e. those closer to the camera are rendered first.
+        front_to_back,
+
+        /// Objects are rendered back-to-front, i.e. those closer to the camera are rendered last.
+        back_to_front,
     };
 
     /// The type of materials to render in this pass. Must match
     /// #khepri::renderer::MaterialDesc::type.
     std::string material_type;
 
-    /// Face culling mode of this render pass.
-    CullMode cull_mode{CullMode::none};
-
     /// How to depth-sort the objects assigned to this render pass.
     DepthSorting depth_sorting{DepthSorting::none};
 
-    /// Type of alpha blending to use for this render pass.
-    AlphaBlendMode alpha_blend_mode{AlphaBlendMode::none};
-
-    /// Depth-buffer settings to use for this render pass.
-    std::optional<DepthBufferDesc> depth_buffer;
+    /// Default values for the graphics pipeline options. Materials can override these.
+    GraphicsPipelineOptions default_graphics_pipeline_options;
 };
 
 /**

--- a/openglyph/CMakeLists.txt
+++ b/openglyph/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(${PROJECT_NAME}
     src/io/chunk_reader.cpp
     src/io/mega_filesystem.cpp
     src/io/mega_file.cpp
+    src/renderer/io/graphics_pipeline_options.cpp
     src/renderer/io/material.cpp
     src/renderer/io/model.cpp
     src/renderer/io/render_pipeline.cpp

--- a/openglyph/include/openglyph/parser/parsers.hpp
+++ b/openglyph/include/openglyph/parser/parsers.hpp
@@ -51,12 +51,36 @@ struct Parser
     static std::optional<T> parse(std::string_view) = delete;
 };
 
+/**
+ * Attempts to parse @a str as type @a T.
+ *
+ * Returns @a std::nullopt if @a str cannot be parsed as @a T.
+ */
 template <typename T>
 std::optional<T> try_parse(std::string_view str)
 {
     return Parser<T>::parse(khepri::trim(str));
 }
 
+/**
+ * Attempts to parse @a *str as type @a T, if @a str has a value.
+ *
+ * Returns @a std::nullopt if @a str does not have a value, or cannot be parsed as @a T.
+ */
+template <typename T>
+std::optional<T> try_parse(const std::optional<std::string_view>& str)
+{
+    if (str) {
+        return try_parse<T>(*str);
+    }
+    return {};
+}
+
+/**
+ * Parse @a str as type @a T.
+ *
+ * Throws openglyph::ParseError if @str cannot be parsed as @a T.
+ */
 template <typename T>
 T parse(std::string_view str)
 {
@@ -65,6 +89,21 @@ T parse(std::string_view str)
         throw ParseError("\"" + std::string(str) + "\" is not a valid value");
     }
     return *val;
+}
+
+/**
+ * Parse @a *str as type @a T, if @a str has a value.
+ *
+ * Returns @a std::nullopt if @a str does not have a value, or openglyph::ParseError if it does but
+ * cannot be parsed as @a T.
+ */
+template <typename T>
+std::optional<T> parse(const std::optional<std::string_view>& str)
+{
+    if (str) {
+        return parse<T>(*str);
+    }
+    return {};
 }
 
 //

--- a/openglyph/include/openglyph/parser/xml_parser.hpp
+++ b/openglyph/include/openglyph/parser/xml_parser.hpp
@@ -348,7 +348,27 @@ inline std::string_view require_child(const openglyph::XmlParser::Node& node, st
 }
 
 /**
- * Returns the contents of an optional child node with default.
+ * Returns the contents of an optional child node or std::nullopt if it's missing.
+ *
+ * Returns the contents of the node's child that has the specified name. If multiple
+ * children match, returns the first. If no children match, or if the child has children of its own,
+ * returns @a std::nullopt.
+ *
+ * @note the name lookup is case-insensitive.
+ */
+inline std::optional<std::string_view> optional_child(const openglyph::XmlParser::Node& node,
+                                                      std::string_view                  name)
+{
+    if (auto child = node.child(name)) {
+        if (child->nodes().empty()) {
+            return child->value();
+        }
+    }
+    return {};
+}
+
+/**
+ * Returns the contents of an optional child node, or a default value if its missing.
  *
  * Returns the contents of the node's child that has the specified name. If multiple
  * children match, returns the first. If no children match, or if the child has children of its own,

--- a/openglyph/include/openglyph/renderer/material_desc.hpp
+++ b/openglyph/include/openglyph/renderer/material_desc.hpp
@@ -43,6 +43,9 @@ struct MaterialDesc
 
     /// Shader properties of this material
     std::vector<Property> properties;
+
+    /// Graphics pipeline options for this material.
+    khepri::renderer::GraphicsPipelineOptions graphics_pipeline_options;
 };
 
 } // namespace openglyph::renderer

--- a/openglyph/src/renderer/io/graphics_pipeline_options.cpp
+++ b/openglyph/src/renderer/io/graphics_pipeline_options.cpp
@@ -1,0 +1,99 @@
+#include "graphics_pipeline_options.hpp"
+
+#include <openglyph/parser/parsers.hpp>
+
+namespace openglyph {
+template <>
+struct Parser<khepri::renderer::GraphicsPipelineOptions::CullMode>
+{
+    using CullMode = khepri::renderer::GraphicsPipelineOptions::CullMode;
+
+    static std::optional<CullMode> parse(std::string_view str) noexcept
+    {
+        if (khepri::case_insensitive_equals(str, "none")) {
+            return CullMode::none;
+        }
+        if (khepri::case_insensitive_equals(str, "back")) {
+            return CullMode::back;
+        }
+        if (khepri::case_insensitive_equals(str, "front")) {
+            return CullMode::front;
+        }
+        return {};
+    }
+};
+
+template <>
+struct Parser<khepri::renderer::GraphicsPipelineOptions::AlphaBlendMode>
+{
+    using AlphaBlendMode = khepri::renderer::GraphicsPipelineOptions::AlphaBlendMode;
+
+    static std::optional<AlphaBlendMode> parse(std::string_view str) noexcept
+    {
+        if (khepri::case_insensitive_equals(str, "none")) {
+            return AlphaBlendMode::none;
+        }
+        if (khepri::case_insensitive_equals(str, "blend_src")) {
+            return AlphaBlendMode::blend_src;
+        }
+        if (khepri::case_insensitive_equals(str, "additive")) {
+            return AlphaBlendMode::additive;
+        }
+        return {};
+    }
+};
+
+template <>
+struct Parser<khepri::renderer::GraphicsPipelineOptions::ComparisonFunc>
+{
+    using ComparisonFunc = khepri::renderer::GraphicsPipelineOptions::ComparisonFunc;
+
+    static std::optional<ComparisonFunc> parse(std::string_view str) noexcept
+    {
+        if (khepri::case_insensitive_equals(str, "never")) {
+            return ComparisonFunc::never;
+        }
+        if (khepri::case_insensitive_equals(str, "less")) {
+            return ComparisonFunc::less;
+        }
+        if (khepri::case_insensitive_equals(str, "equal")) {
+            return ComparisonFunc::equal;
+        }
+        if (khepri::case_insensitive_equals(str, "less_equal")) {
+            return ComparisonFunc::less_equal;
+        }
+        if (khepri::case_insensitive_equals(str, "greater")) {
+            return ComparisonFunc::greater;
+        }
+        if (khepri::case_insensitive_equals(str, "not_equal")) {
+            return ComparisonFunc::not_equal;
+        }
+        if (khepri::case_insensitive_equals(str, "greater_equal")) {
+            return ComparisonFunc::greater_equal;
+        }
+        if (khepri::case_insensitive_equals(str, "always")) {
+            return ComparisonFunc::always;
+        }
+        return {};
+    }
+};
+
+namespace renderer::io {
+khepri::renderer::GraphicsPipelineOptions
+parse_graphics_pipeline_options(const openglyph::XmlParser::Node& node)
+{
+    khepri::renderer::GraphicsPipelineOptions options;
+    options.cull_mode = parse<khepri::renderer::GraphicsPipelineOptions::CullMode>(
+        optional_child(node, "Cull_Mode"));
+    options.front_ccw        = parse<bool>(optional_child(node, "Front_CCW"));
+    options.alpha_blend_mode = parse<khepri::renderer::GraphicsPipelineOptions::AlphaBlendMode>(
+        optional_child(node, "Alpha_Blend"));
+    options.depth_enable = parse<bool>(optional_child(node, "Depth_Enable"));
+    options.depth_comparison_func =
+        parse<khepri::renderer::GraphicsPipelineOptions::ComparisonFunc>(
+            optional_child(node, "Depth_Func"));
+    options.depth_write_enable = parse<bool>(optional_child(node, "Depth_Write_Enable"));
+    return options;
+}
+} // namespace renderer::io
+} // namespace openglyph

--- a/openglyph/src/renderer/io/graphics_pipeline_options.hpp
+++ b/openglyph/src/renderer/io/graphics_pipeline_options.hpp
@@ -1,0 +1,10 @@
+#include <khepri/renderer/render_pipeline_desc.hpp>
+
+#include <openglyph/parser/xml_parser.hpp>
+
+namespace openglyph::renderer::io {
+
+khepri::renderer::GraphicsPipelineOptions
+parse_graphics_pipeline_options(const openglyph::XmlParser::Node& node);
+
+} // namespace openglyph::renderer::io

--- a/openglyph/src/renderer/io/material.cpp
+++ b/openglyph/src/renderer/io/material.cpp
@@ -1,3 +1,5 @@
+#include "graphics_pipeline_options.hpp"
+
 #include <khepri/log/log.hpp>
 
 #include <openglyph/parser/parsers.hpp>
@@ -60,6 +62,7 @@ auto load_material(const openglyph::XmlParser::Node& node)
     material_desc.num_directional_lights =
         parse<int>(optional_child(node, "Num_Directional_Lights", "0"));
     material_desc.num_point_lights = parse<int>(optional_child(node, "Num_Point_Lights", "0"));
+    material_desc.graphics_pipeline_options = parse_graphics_pipeline_options(node);
 
     for (const auto& propnode : node.nodes()) {
         if (propnode.name() == "Param") {

--- a/openglyph/src/renderer/io/render_pipeline.cpp
+++ b/openglyph/src/renderer/io/render_pipeline.cpp
@@ -1,3 +1,5 @@
+#include "graphics_pipeline_options.hpp"
+
 #include <khepri/log/log.hpp>
 
 #include <openglyph/parser/parsers.hpp>
@@ -25,61 +27,6 @@ struct Parser<khepri::renderer::RenderPassDesc::DepthSorting>
     }
 };
 
-template <>
-struct Parser<khepri::renderer::RenderPassDesc::AlphaBlendMode>
-{
-    using AlphaBlendMode = khepri::renderer::RenderPassDesc::AlphaBlendMode;
-
-    static std::optional<AlphaBlendMode> parse(std::string_view str) noexcept
-    {
-        if (khepri::case_insensitive_equals(str, "none")) {
-            return AlphaBlendMode::none;
-        }
-        if (khepri::case_insensitive_equals(str, "blend_src")) {
-            return AlphaBlendMode::blend_src;
-        }
-        if (khepri::case_insensitive_equals(str, "additive")) {
-            return AlphaBlendMode::additive;
-        }
-        return {};
-    }
-};
-
-template <>
-struct Parser<khepri::renderer::RenderPassDesc::ComparisonFunc>
-{
-    using ComparisonFunc = khepri::renderer::RenderPassDesc::ComparisonFunc;
-
-    static std::optional<ComparisonFunc> parse(std::string_view str) noexcept
-    {
-        if (khepri::case_insensitive_equals(str, "never")) {
-            return ComparisonFunc::never;
-        }
-        if (khepri::case_insensitive_equals(str, "less")) {
-            return ComparisonFunc::less;
-        }
-        if (khepri::case_insensitive_equals(str, "equal")) {
-            return ComparisonFunc::equal;
-        }
-        if (khepri::case_insensitive_equals(str, "less_equal")) {
-            return ComparisonFunc::less_equal;
-        }
-        if (khepri::case_insensitive_equals(str, "greater")) {
-            return ComparisonFunc::greater;
-        }
-        if (khepri::case_insensitive_equals(str, "not_equal")) {
-            return ComparisonFunc::not_equal;
-        }
-        if (khepri::case_insensitive_equals(str, "greater_equal")) {
-            return ComparisonFunc::greater_equal;
-        }
-        if (khepri::case_insensitive_equals(str, "always")) {
-            return ComparisonFunc::always;
-        }
-        return {};
-    }
-};
-
 namespace renderer::io {
 namespace {
 auto load_render_pass(const openglyph::XmlParser::Node& node)
@@ -88,17 +35,7 @@ auto load_render_pass(const openglyph::XmlParser::Node& node)
     render_pass.material_type = optional_child(node, "Material_Type", "");
     render_pass.depth_sorting = parse<khepri::renderer::RenderPassDesc::DepthSorting>(
         optional_child(node, "Depth_Sort", "None"));
-    render_pass.alpha_blend_mode = parse<khepri::renderer::RenderPassDesc::AlphaBlendMode>(
-        optional_child(node, "AlphaBlend", "none"));
-
-    if (openglyph::parse<bool>(optional_child(node, "DepthEnable", "true"))) {
-        khepri::renderer::RenderPassDesc::DepthBufferDesc desc{};
-        desc.comparison_func = parse<khepri::renderer::RenderPassDesc::ComparisonFunc>(
-            optional_child(node, "DepthFunc", "less"));
-        desc.write_enable        = parse<bool>(optional_child(node, "DepthWriteEnable", "true"));
-        render_pass.depth_buffer = desc;
-    }
-
+    render_pass.default_graphics_pipeline_options = parse_graphics_pipeline_options(node);
     return render_pass;
 }
 

--- a/openglyph/src/renderer/material_store.cpp
+++ b/openglyph/src/renderer/material_store.cpp
@@ -26,10 +26,11 @@ void MaterialStore::register_materials(
 {
     for (const auto& desc : material_descs) {
         khepri::renderer::MaterialDesc info;
-        info.type                   = desc.type;
-        info.shader                 = m_shader_loader(desc.shader);
-        info.num_directional_lights = desc.num_directional_lights;
-        info.num_point_lights       = desc.num_point_lights;
+        info.type                      = desc.type;
+        info.shader                    = m_shader_loader(desc.shader);
+        info.num_directional_lights    = desc.num_directional_lights;
+        info.num_point_lights          = desc.num_point_lights;
+        info.graphics_pipeline_options = desc.graphics_pipeline_options;
         for (const auto& property : desc.properties) {
             khepri::renderer::MaterialDesc::Property prop;
             prop.name = property.name;


### PR DESCRIPTION
Materials that should be alpha-blended (i.e. (SrcAlpha, InvSrcAlpha)) were instead additive-blended (i.e. (One, One)). This was caused by the alpha-blending settings being fixed in the "Transparent" render pass, whereas different Transparent meshes require may different alpha blending.

Since we already create a separate graphics pipeline for each Material (because the shaders differ), the fix was to introduce the same graphics pipeline options that are in the render pass, in the material. Then, the render pass options act as a default, and the material options can override them.

Fixes #83.