### PR TITLE
feat: set initial camera

### DIFF
--- a/khepri/CMakeLists.txt
+++ b/khepri/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${PROJECT_NAME}
     src/io/stream.cpp
     src/log/log.cpp
     src/math/interpolator.cpp
+    src/math/polynomial.cpp
     src/math/spline.cpp
     src/physics/collision_mesh.cpp
     src/renderer/io/kmf.cpp

--- a/khepri/include/khepri/game/rts_camera.hpp
+++ b/khepri/include/khepri/game/rts_camera.hpp
@@ -155,6 +155,9 @@ public:
      * This effectively changes the yaw and pitch of the camera, but keeps the distance to the
      * target the same. The camera's new yaw and pitch are bound by their configured constraints.
      *
+     * The arguments to this method are scaled by the \a sensitivity field of the yaw and pitch
+     * property, respectively.
+     *
      * @note the @a pitch_angle_diff parameter is ignored if pitch is controlled via zoom (see \ref
      * pitch_constraint).
      *

--- a/khepri/include/khepri/math/interpolator.hpp
+++ b/khepri/include/khepri/math/interpolator.hpp
@@ -2,6 +2,8 @@
 
 #include "polynomial.hpp"
 
+#include <memory>
+#include <optional>
 #include <vector>
 
 namespace khepri {
@@ -18,11 +20,22 @@ public:
     virtual ~Interpolator() = default;
 
     /**
+     * \brief Returns a copy of the interpolator.
+     */
+    [[nodiscard]] virtual std::unique_ptr<Interpolator> clone() const = 0;
+
+    /**
      * \brief Return interpolated y value for a given x value.
      *
      * \note x is clamped to the input range for the interpolator.
      */
     [[nodiscard]] virtual double interpolate(double x) const noexcept = 0;
+
+    /**
+     * \brief Returns the smallest x value (if any) that, when passed to #interpolate(), results in
+     * a value greater than or equal to y.
+     */
+    [[nodiscard]] virtual std::optional<double> lower_bound(double y) const noexcept = 0;
 };
 
 /**
@@ -46,8 +59,14 @@ public:
      */
     explicit StepInterpolator(std::vector<Point> points);
 
+    /// \see Interpolator::clone
+    [[nodiscard]] std::unique_ptr<Interpolator> clone() const override;
+
     /// \see Interpolator::interpolate
     [[nodiscard]] double interpolate(double x) const noexcept override;
+
+    /// \see Interpolator::lower_bound
+    [[nodiscard]] std::optional<double> lower_bound(double y) const noexcept override;
 
 private:
     std::vector<Point> m_points;
@@ -74,8 +93,14 @@ public:
      */
     explicit LinearInterpolator(std::vector<Point> points);
 
+    /// \see Interpolator::clone
+    [[nodiscard]] std::unique_ptr<Interpolator> clone() const override;
+
     /// \see Interpolator::interpolate
     [[nodiscard]] double interpolate(double x) const noexcept override;
+
+    /// \see Interpolator::lower_bound
+    [[nodiscard]] std::optional<double> lower_bound(double y) const noexcept override;
 
 private:
     std::vector<Point> m_points;
@@ -104,8 +129,14 @@ public:
      */
     explicit CosineInterpolator(std::vector<Point> points);
 
+    /// \see Interpolator::clone
+    [[nodiscard]] std::unique_ptr<Interpolator> clone() const override;
+
     /// \see Interpolator::interpolate
     [[nodiscard]] double interpolate(double x) const noexcept override;
+
+    /// \see Interpolator::lower_bound
+    [[nodiscard]] std::optional<double> lower_bound(double y) const noexcept override;
 
 private:
     std::vector<Point> m_points;
@@ -134,8 +165,14 @@ public:
      */
     explicit CubicInterpolator(std::vector<Point> points);
 
+    /// \see Interpolator::clone
+    [[nodiscard]] std::unique_ptr<Interpolator> clone() const override;
+
     /// \see Interpolator::interpolate
     [[nodiscard]] double interpolate(double x) const noexcept override;
+
+    /// \see Interpolator::lower_bound
+    [[nodiscard]] std::optional<double> lower_bound(double y) const noexcept override;
 
     /// Returns the points used to construct this interpolator
     [[nodiscard]] gsl::span<const Point> points() const noexcept

--- a/khepri/include/khepri/math/math.hpp
+++ b/khepri/include/khepri/math/math.hpp
@@ -21,6 +21,14 @@ inline T lerp(const T& v0, const T& v1, double t) noexcept
 }
 
 /**
+ * Checks if two floating-point values are near enough to be considered equal.
+ */
+inline bool is_near(double v1, double v2, double max_diff = 0.00000001) noexcept
+{
+    return std::abs(v1 - v2) < max_diff;
+}
+
+/**
  * \brief Clamps a value between two extremes
  *
  * Returns \a min if \a val < \a min.

--- a/khepri/include/khepri/math/polynomial.hpp
+++ b/khepri/include/khepri/math/polynomial.hpp
@@ -2,6 +2,8 @@
 
 #include "point.hpp"
 
+#include <khepri/math/math.hpp>
+
 #include <gsl/gsl-lite.hpp>
 
 #include <array>
@@ -9,6 +11,9 @@
 #include <vector>
 
 namespace khepri {
+namespace detail {
+std::vector<double> solve_polynomial(double y, gsl::span<const double> coefficients);
+}
 
 /**
  * \brief A generic N-degree polynomial
@@ -35,6 +40,19 @@ struct Polynomial
             y = coefficients[i - 1] + x * y;
         }
         return y;
+    }
+
+    /**
+     * @brief Returns all real x values (sorted ascending) that, when passed to #sample(), results
+     * in the given @a y.
+     *
+     * @note this method only works for polynomials of degree less than five (see the Abel-Ruffini
+     * theorem).
+     */
+    [[nodiscard]] constexpr std::vector<double> solve(double y) const
+    {
+        static_assert(Degree < 5);
+        return detail::solve_polynomial(y, coefficients);
     }
 
     /**
@@ -82,6 +100,14 @@ struct QuadraticPolynomial : public Polynomial<2>
  * Cubic polynomials are defined as y = a + b·x + c·x² + d·x³.
  */
 struct CubicPolynomial : public Polynomial<3>
+{};
+
+/**
+ * @brief A fourth-degree (quartic) polynomial
+ *
+ * Quartic polynomials are defined as y = a + b·x + c·x² + d·x³ + e·x⁴.
+ */
+struct QuarticPolynomial : public Polynomial<4>
 {};
 
 } // namespace khepri

--- a/khepri/include/khepri/scene/scene.hpp
+++ b/khepri/include/khepri/scene/scene.hpp
@@ -40,13 +40,28 @@ public:
     }
 
     /**
-     * Remvoes an object from the scene.
+     * Removes an object from the scene.
      *
      * Does nothing if the object is not in the scene.
      */
     void remove_object(const std::shared_ptr<SceneObject>& object)
     {
         m_objects.erase(object);
+    }
+
+    /**
+     * Returns all objects in the scene that have a specified behavior.
+     */
+    template <typename BehaviorType>
+    std::vector<std::shared_ptr<SceneObject>> objects() const
+    {
+        std::vector<std::shared_ptr<SceneObject>> result;
+        for (const auto& object : m_objects) {
+            if (object->behavior<BehaviorType>()) {
+                result.push_back(object);
+            }
+        }
+        return result;
     }
 
 private:

--- a/khepri/src/math/polynomial.cpp
+++ b/khepri/src/math/polynomial.cpp
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <khepri/math/math.hpp>
+#include <khepri/math/polynomial.hpp>
+
+#include <cassert>
+
+namespace khepri::detail {
+namespace {
+
+// Solve a constant function: y = c₀
+std::vector<double> solve_constant(double y, gsl::span<const double> coefficients)
+{
+    // Solution: x = ℝ (set of all real numbers) iff. y = c₀
+    assert(coefficients.size() == 1);
+    if (is_near(y, coefficients[0])) {
+        // Technically we should return all possible x, but that's not really doable.
+        return {0.0};
+    }
+    return {};
+}
+
+// Solve a linear polynomial: y = c₀ + c₁·x
+std::vector<double> solve_linear_polynomial(double y, gsl::span<const double> coefficients)
+{
+    // Solution: x = (y - c₀)/c₁
+    assert(coefficients.size() == 2);
+    return {(y - coefficients[0]) / coefficients[1]};
+}
+
+// Solve a quadratic polynomial: y = c₀ + c₁·x +  c₂·x²
+std::vector<double> solve_quadratic_polynomial(double y, gsl::span<const double> coefficients)
+{
+    assert(coefficients.size() == 3);
+    const auto a = coefficients[2], b = coefficients[1], c = coefficients[0] - y;
+    // Solution: x = (-b ± √(b² - 4ac)) / 2a
+    if (const auto D = b * b - 4 * a * c; D >= 0) {
+        // There's a solution.
+        const auto sqrt_D = std::sqrt(D);
+        return {(-b - sqrt_D) / (2 * a), (-b + sqrt_D) / (2 * a)};
+    }
+    return {};
+}
+
+// Solve a cubic polynomial: y = c₀ + c₁·x + c₂·x² + c₃·x³
+std::vector<double> solve_cubic_polynomial(double y, gsl::span<const double> coefficients)
+{
+    assert(coefficients.size() == 4);
+    // First, rewrite to make c₃ = 1 (without loss of generality):
+    // Cubic: (c₀-y)/c₃ + c₁/c₃·x + c₂/c₃·x² + x³ = 0
+    const auto a0 = (coefficients[0] - y) / coefficients[3];
+    const auto a1 = coefficients[1] / coefficients[3];
+    const auto a2 = coefficients[2] / coefficients[3];
+
+    // Then, the three solutions are (Cardano's formula):
+    //   x₁ = -⅓a₂ + S + T
+    //   x₂ = -⅓a₂ - ½(S + T) + ½√3𝑖(S - T)
+    //   x₃ = -⅓a₂ - ½(S + T) - ½√3𝑖(S - T)
+    // With:
+    //   Q = (3a₁ - a₂²)/9,  R = (9a₂a₁ - 27a₀ - 2a₂³)/54,
+    //   S = ∛(R + √D),  T = ∛(R - √D), and D = Q³ + R²
+
+    const auto Q = (3 * a1 - a2 * a2) / 9;
+    const auto R = (9 * a2 * a1 - 27 * a0 - 2 * a2 * a2 * a2) / 54;
+    const auto D = Q * Q * Q + R * R;
+    if (is_near(D, 0.0)) {
+        // If D is zero, S and T are equal, the imaginary component in x₂ and x₃
+        // disappears and they become equal. So then we have two real solutions.
+        const auto S = std::cbrt(R);
+
+        auto x1 = 2 * S - a2 / 3;
+        auto x2 = -S - a2 / 3;
+        if (is_near(x1, x2)) {
+            return {x1};
+        }
+        // Sort the result
+        if (x2 < x1) {
+            std::swap(x1, x2);
+        }
+        return {x1, x2};
+    }
+
+    if (D > 0) {
+        // If D is positive, S and T are different real numbers, and x₂ and x₃ become
+        // complex numbers. We only want real solutions, so we ignore them.
+        const auto sqrt_D = std::sqrt(D);
+        const auto S      = std::cbrt(R + sqrt_D);
+        const auto T      = std::cbrt(R - sqrt_D);
+        return {S + T - a2 / 3};
+    }
+
+    // If D is negative, S and T are complex numbers. These eventually factor out to result
+    // in three real numbers as follows:
+    //   θ  = cos⁻¹(R / √(-Q³))
+    //   x₁ = -⅓a₂ + 2√(-Q)cos(θ/3)
+    //   x₂ = -⅓a₂ + 2√(-Q)cos((θ+2π)/3)
+    //   x₃ = -⅓a₂ + 2√(-Q)cos((θ+4π)/3)
+    assert(Q <= 0);
+    const auto theta  = std::acos(R / std::sqrt(-Q * Q * Q));
+    const auto sqrt_Q = 2 * std::sqrt(-Q);
+
+    auto x1 = sqrt_Q * std::cos(theta / 3) - a2 / 3;
+    auto x2 = sqrt_Q * std::cos((theta + 2 * PI) / 3) - a2 / 3;
+    auto x3 = sqrt_Q * std::cos((theta + 4 * PI) / 3) - a2 / 3;
+    // Sort the result
+    if (x2 < x1) {
+        std::swap(x1, x2);
+    }
+    if (x3 < x2) {
+        std::swap(x3, x2);
+        if (x2 < x1) {
+            std::swap(x1, x2);
+        }
+    }
+    return {x1, x2, x3};
+}
+
+// Solve a quartic polynomial: y = c₀ + c₁·x + c₂·x² + c₃·x³ + c₄·x⁴
+std::vector<double> solve_quartic_polynomial(double y, gsl::span<const double> coefficients)
+{
+    assert(coefficients.size() == 5);
+
+    // Apply the quartic formula.
+    // First normalize the quartic into a monic by dividing by c₄: x⁴ + bx³ + cx² + dx + e = 0, with
+    // b = c₃/c₄, c = c₂/c₄, d = c₁/c₄ and e = (c₀-y)/c₄
+    const auto b = coefficients[3] / coefficients[4], c = coefficients[2] / coefficients[4],
+               d = coefficients[1] / coefficients[4], e = (coefficients[0] - y) / coefficients[4];
+
+    // Then, solve the resolvent cubic: z³ - cz² + (db - 4e)z + (4ce - d² - b²e) = 0
+    const auto cubic_coefficients =
+        std::array<double, 4>{4 * c * e - d * d - b * b * e, d * b - 4 * e, -c, 1};
+    const auto zs = solve_cubic_polynomial(0, cubic_coefficients);
+    if (zs.empty()) {
+        // No solutions
+        return {};
+    }
+
+    // Use a non-zero real root of the cubic (largest for better precision)
+    auto it = std::find_if(zs.rbegin(), zs.rend(), [](auto v) { return !is_near(v, 0); });
+    if (it == zs.rend()) {
+        // The resolvent cubic only has a single solution: 0.
+        // That means the logic below won't work nicely, but we have a single solution anyway.
+        return {0};
+    }
+    const auto z = *it;
+
+    // Then, calculate the solutions to the monic quartic
+    const auto R = std::sqrt(b * b / 4 - c + z) / 2;
+    const auto m = (b * b * 3 / 16 - R * R - c / 2);
+    const auto n =
+        is_near(R, 0) ? std::sqrt(z * z / 4 - e) : (b * c / 8 - d / 4 - b * b * b / 32) / R;
+
+    std::vector<double> xs;
+    if (m + n >= 0) {
+        const auto D = std::sqrt(m + n);
+        xs.push_back(b / -4 + R + D);
+        if (!is_near(D, 0)) {
+            xs.push_back(b / -4 + R - D);
+        }
+    }
+
+    if (m >= n) {
+        const auto E = std::sqrt(m - n);
+        xs.push_back(b / -4 - R + E);
+        if (!is_near(E, 0)) {
+            xs.push_back(b / -4 - R - E);
+        }
+    }
+
+    std::sort(xs.begin(), xs.end());
+    return xs;
+}
+
+} // namespace
+
+std::vector<double> solve_polynomial(double y, gsl::span<const double> coefficients)
+{
+    // By the Abel-Ruffini theorem, there are only exact solutions for polynomials up to
+    // degree 4. Numerical root-finding methods are quite complicated, and can be very sensitive to
+    // errors in floating-point arithmethic (see Wilkinson's Polynomial). They'd need
+    // arbitrary-precision decimal math types. This is simply too much, and the need for games to
+    // solve fifth-degree-or-higher polynomials is quite low, so we just don't support it.
+    assert(coefficients.size() >= 1 && coefficients.size() < 5);
+
+    // The number of coefficients is always 1 + the polynomial degree.
+    const std::size_t degree = coefficients.size() - 1;
+
+    if (degree >= 5) {
+        return {};
+    }
+
+    // The exact solutions require the highest coefficient to not be zero. Otherwise, it's really a
+    // lesser-degree polynomial. That's why we check the coefficients here.
+
+    if (degree >= 4 && !is_near(coefficients[4], 0.0)) {
+        return solve_quartic_polynomial(y, coefficients.subspan(0, 5));
+    }
+
+    if (degree >= 3 && !is_near(coefficients[3], 0.0)) {
+        return solve_cubic_polynomial(y, coefficients.subspan(0, 4));
+    }
+
+    if (degree >= 2 && !is_near(coefficients[2], 0.0)) {
+        return solve_quadratic_polynomial(y, coefficients.subspan(0, 3));
+    }
+
+    if (degree >= 1 && !is_near(coefficients[1], 0.0)) {
+        return solve_linear_polynomial(y, coefficients.subspan(0, 2));
+    }
+
+    return solve_constant(y, coefficients.subspan(0, 1));
+}
+
+} // namespace khepri::detail

--- a/khepri/tests/polynomial_test.cpp
+++ b/khepri/tests/polynomial_test.cpp
@@ -7,20 +7,36 @@
 
 using khepri::CubicPolynomial;
 using khepri::LinearPolynomial;
+using khepri::Polynomial;
 using khepri::QuadraticPolynomial;
+using khepri::QuarticPolynomial;
+using testing::DoubleNear;
+using testing::ElementsAre;
 
 TEST(PolynomialTest, LinearPolynomial)
 {
+    // f(x) = 2x + 1
     const LinearPolynomial p{1, 2};
+
+    // Sample
     EXPECT_EQ(p.sample(0), 1);
     EXPECT_EQ(p.sample(1), 3);
     EXPECT_EQ(p.sample(10), 21);
 
+    // Solve
+    constexpr double max_error = 1e-6;
+    EXPECT_THAT(p.solve(6), ElementsAre(DoubleNear(2.5, max_error)));
+    EXPECT_THAT(p.solve(2), ElementsAre(DoubleNear(0.5, max_error)));
+    EXPECT_THAT(p.solve(0), ElementsAre(DoubleNear(-0.5, max_error)));
+    EXPECT_THAT(p.solve(-100), ElementsAre(DoubleNear(-50.5, max_error)));
+
+    // Sample first derivative (f'(x) = 2)
     const auto& d = p.derivative();
     EXPECT_EQ(d.sample(0), 2);
     EXPECT_EQ(d.sample(1), 2);
     EXPECT_EQ(d.sample(10), 2);
 
+    // Sample second derivative (f''(x) = 0)
     const auto& dd = d.derivative();
     EXPECT_EQ(dd.sample(0), 0);
     EXPECT_EQ(dd.sample(1), 0);
@@ -29,21 +45,35 @@ TEST(PolynomialTest, LinearPolynomial)
 
 TEST(PolynomialTest, QuadraticPolynomial)
 {
+    // f(x) = 3x² + 2x + 1, a parabola with its minimum at (-1/3, 2/3).
     const QuadraticPolynomial p{1, 2, 3};
+
+    // Sample
     EXPECT_EQ(p.sample(0), 1);
     EXPECT_EQ(p.sample(1), 6);
     EXPECT_EQ(p.sample(10), 321);
 
+    // Solve
+    constexpr double max_error = 1e-6;
+    EXPECT_THAT(p.solve(0), ElementsAre());
+    EXPECT_THAT(p.solve(0.5), ElementsAre());
+    EXPECT_THAT(p.solve(2), ElementsAre(DoubleNear(-1, max_error), DoubleNear(1.0 / 3, max_error)));
+    EXPECT_THAT(p.solve(100),
+                ElementsAre(DoubleNear(-6.08755883, max_error), DoubleNear(5.42089217, max_error)));
+
+    // Sample first derivative (f'(x) = 6x + 2)
     const auto& d = p.derivative();
     EXPECT_EQ(d.sample(0), 2);
     EXPECT_EQ(d.sample(1), 8);
     EXPECT_EQ(d.sample(10), 62);
 
+    // Sample second derivative (f''(x) = 6)
     const auto& dd = d.derivative();
     EXPECT_EQ(dd.sample(0), 6);
     EXPECT_EQ(dd.sample(1), 6);
     EXPECT_EQ(dd.sample(10), 6);
 
+    // Sample third derivative (f'''(x) = 0)
     const auto& ddd = dd.derivative();
     EXPECT_EQ(ddd.sample(0), 0);
     EXPECT_EQ(ddd.sample(1), 0);
@@ -52,28 +82,130 @@ TEST(PolynomialTest, QuadraticPolynomial)
 
 TEST(PolynomialTest, CubicPolynomial)
 {
+    // f(x) = 4x³ + 3x² + 2x + 1, a cubic without local minima or maxima
     const CubicPolynomial p{1, 2, 3, 4};
+    // Sample
     EXPECT_EQ(p.sample(0), 1);
     EXPECT_EQ(p.sample(1), 10);
     EXPECT_EQ(p.sample(10), 4321);
 
+    // Solve. Because it has no local minima or maxima, there's only ever one solution.
+    constexpr double max_error = 1e-6;
+    EXPECT_THAT(p.solve(-10), ElementsAre(DoubleNear(-1.55977729, max_error)));
+    EXPECT_THAT(p.solve(0), ElementsAre(DoubleNear(-0.60582959, max_error)));
+    EXPECT_THAT(p.solve(1), ElementsAre(DoubleNear(0, max_error)));
+    EXPECT_THAT(p.solve(10), ElementsAre(DoubleNear(1, max_error)));
+
+    // Solve f(x) = 4x³ - 3x² + 1, with a local maximum at (0, 1) and a local minimum at (2, -3).
+    const CubicPolynomial p2{1, 0, -3, 1};
+    // Local minimum/maximum; two solutions
+    EXPECT_THAT(p2.solve(1), ElementsAre(DoubleNear(0, max_error), DoubleNear(3, max_error)));
+    EXPECT_THAT(p2.solve(-3), ElementsAre(DoubleNear(-1, max_error), DoubleNear(2, max_error)));
+    // Point in between, three solutions
+    EXPECT_THAT(p2.solve(0),
+                ElementsAre(DoubleNear(-0.53208889, max_error), DoubleNear(0.65270364, max_error),
+                            DoubleNear(2.87938524, max_error)));
+    // Outside: one solution
+    EXPECT_THAT(p2.solve(5), ElementsAre(DoubleNear(3.3553014, max_error)));
+    EXPECT_THAT(p2.solve(-5), ElementsAre(DoubleNear(-1.19582335, max_error)));
+
+    // Sample first derivative (f'(x) = 12x² + 6x + 2)
     const auto& d = p.derivative();
     EXPECT_EQ(d.sample(0), 2);
     EXPECT_EQ(d.sample(1), 20);
     EXPECT_EQ(d.sample(10), 1262);
 
+    // Sample second derivative (f''(x) = 24x + 6)
     const auto& dd = d.derivative();
     EXPECT_EQ(dd.sample(0), 6);
     EXPECT_EQ(dd.sample(1), 30);
     EXPECT_EQ(dd.sample(10), 246);
 
+    // Sample third derivative (f'''(x) = 24)
     const auto& ddd = dd.derivative();
     EXPECT_EQ(ddd.sample(0), 24);
     EXPECT_EQ(ddd.sample(1), 24);
     EXPECT_EQ(ddd.sample(10), 24);
 
+    // Sample fourth derivative (f''''(x) = 0)
     const auto& dddd = ddd.derivative();
     EXPECT_EQ(dddd.sample(0), 0);
     EXPECT_EQ(dddd.sample(1), 0);
     EXPECT_EQ(dddd.sample(10), 0);
+}
+
+TEST(PolynomialTest, QuarticPolynomial)
+{
+    // f(x) = 5x⁴ + 4x³ + 3x² + 2x + 1, a quartic with minimum at approx. (-0.4370802, 0.54743896)
+    const QuarticPolynomial p{1, 2, 3, 4, 5};
+    // Sample
+    EXPECT_EQ(p.sample(0), 1);
+    EXPECT_EQ(p.sample(1), 15);
+    EXPECT_EQ(p.sample(10), 54321);
+
+    // Solve.
+    constexpr double max_error = 1e-6;
+    EXPECT_THAT(p.solve(-10), ElementsAre());
+    EXPECT_THAT(p.solve(0), ElementsAre());
+    EXPECT_THAT(p.solve(1),
+                ElementsAre(DoubleNear(-0.72932314, max_error), DoubleNear(0, max_error)));
+    EXPECT_THAT(p.solve(10),
+                ElementsAre(DoubleNear(-1.33371806, max_error), DoubleNear(0.85234477, max_error)));
+
+    // Solve f(x) = x⁴ = 0, which has one real solutions
+    EXPECT_THAT(QuarticPolynomial({0, 0, 0, 0, 1}).solve(0), ElementsAre(DoubleNear(0, max_error)));
+
+    // Solve f(x) = x⁴ + 4x³ - 8x² = -1, which has four real solutions
+    QuarticPolynomial p2{0, 0, -8, 4, 1};
+    EXPECT_THAT(p2.solve(-1),
+                ElementsAre(DoubleNear(-5.45925525, max_error), DoubleNear(-0.32952020, max_error),
+                            DoubleNear(0.40037871, max_error), DoubleNear(1.38839673, max_error)));
+
+    // Solve f(x) = x⁴ + x² + 5 = 5, which has one real solution
+    EXPECT_THAT(QuarticPolynomial({5, 0, 1, 0, 1}).solve(5), ElementsAre(DoubleNear(0, max_error)));
+
+    // Sample first derivative: f'(x) = 20x³ + 12x² + 6x + 2
+    const auto& d = p.derivative();
+    EXPECT_EQ(d.sample(0), 2);
+    EXPECT_EQ(d.sample(1), 40);
+    EXPECT_EQ(d.sample(10), 21262);
+
+    // Sample second derivative: f''(x) = 60x² + 24x + 6
+    const auto& dd = d.derivative();
+    EXPECT_EQ(dd.sample(0), 6);
+    EXPECT_EQ(dd.sample(1), 90);
+    EXPECT_EQ(dd.sample(10), 6246);
+
+    // Sample third derivative: f'''(x) = 120x + 24
+    const auto& ddd = dd.derivative();
+    EXPECT_EQ(ddd.sample(0), 24);
+    EXPECT_EQ(ddd.sample(1), 144);
+    EXPECT_EQ(ddd.sample(10), 1224);
+
+    // Sample fourth derivative: f''''(x) = 120
+    const auto& dddd = ddd.derivative();
+    EXPECT_EQ(dddd.sample(0), 120);
+    EXPECT_EQ(dddd.sample(1), 120);
+    EXPECT_EQ(dddd.sample(10), 120);
+
+    // Sample fifth derivative: f'''''(x) = 0
+    const auto& ddddd = dddd.derivative();
+    EXPECT_EQ(ddddd.sample(0), 0);
+    EXPECT_EQ(ddddd.sample(1), 0);
+    EXPECT_EQ(ddddd.sample(10), 0);
+}
+
+TEST(PolynomialTest, QuinticPolynomial)
+{
+    using QuinticPolynomial = Polynomial<5>;
+
+    // f(x) = 6x⁵ + 5x⁴ + 4x³ + 3x² + 2x + 1
+    const QuinticPolynomial p{1, 2, 3, 4, 5, 6};
+
+    // Sample
+    EXPECT_EQ(p.sample(0), 1);
+    EXPECT_EQ(p.sample(1), 21);
+    EXPECT_EQ(p.sample(10), 654321);
+
+    // We can't solve polynomials of fifth degree or higher.
 }

--- a/openglyph/include/openglyph/game/behaviors/marker_behavior.hpp
+++ b/openglyph/include/openglyph/game/behaviors/marker_behavior.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <khepri/scene/behavior.hpp>
+
+namespace openglyph {
+
+// Special tag behavior for markers.
+class MarkerBehavior : public khepri::scene::Behavior
+{};
+
+} // namespace openglyph

--- a/openglyph/include/openglyph/game/game_object_type.hpp
+++ b/openglyph/include/openglyph/game/game_object_type.hpp
@@ -25,6 +25,9 @@ struct GameObjectType final
 
     /// Should this object be rendered in the background layer?
     bool is_in_background;
+
+    /// Is this type a marker?
+    bool is_marker{false};
 };
 
 } // namespace openglyph

--- a/openglyph/include/openglyph/game/scene.hpp
+++ b/openglyph/include/openglyph/game/scene.hpp
@@ -68,6 +68,16 @@ public:
      */
     void remove_object(const std::shared_ptr<khepri::scene::SceneObject>& object);
 
+    template <typename BehaviorType>
+    std::vector<std::shared_ptr<khepri::scene::SceneObject>> objects() const
+    {
+        // Combine the objects from the foreground and background scenes
+        auto result    = m_foreground_scene.objects<BehaviorType>();
+        auto bg_result = m_background_scene.objects<BehaviorType>();
+        result.insert(result.end(), bg_result.begin(), bg_result.end());
+        return result;
+    }
+
 private:
     // Returns a reference to the scene the object should be placed into
     khepri::scene::Scene& target_scene(const khepri::scene::SceneObject& object);

--- a/openglyph/src/game/game_object_type_store.cpp
+++ b/openglyph/src/game/game_object_type_store.cpp
@@ -2,6 +2,7 @@
 #include <khepri/utility/string.hpp>
 
 #include <gsl/gsl-lite.hpp>
+#include <openglyph/game/behaviors/marker_behavior.hpp>
 #include <openglyph/game/game_object_type_store.hpp>
 #include <openglyph/parser/parsers.hpp>
 
@@ -35,6 +36,14 @@ GameObjectType* GameObjectTypeStore::read_game_object_type(const XmlParser::Node
     type->space_model_name = copy_string(optional_child(node, "Space_Model_Name", ""sv));
     type->scale_factor     = optional_child(node, "Scale_Factor", 1.0);
     type->is_in_background = optional_child(node, "In_Background", false);
+
+    if (auto behavior_str = optional_child(node, "Behavior")) {
+        for (const auto behavior : khepri::split(*behavior_str, ", \t\r\n")) {
+            if (khepri::case_insensitive_equals(behavior, "MARKER")) {
+                type->is_marker = true;
+            }
+        }
+    }
     return type;
 }
 


### PR DESCRIPTION
This change sets the initial camera position & orientation based on the data in XML and the map. Orientation and zoom level is taken from XML. Position of the camera is taken from the map as the first "Player_0_Spawn_Point_Marker" game object. Note that there are typically multiple such markers, one for each faction.