### PR TITLE
ci: avoid build of vulkan-validationlayers

### DIFF
--- a/conan.lock
+++ b/conan.lock
@@ -11,7 +11,7 @@
         "spirv-tools/1.3.224.0",
         "spirv-headers/1.3.224.0",
         "spirv-cross/1.3.224.0",
-        "robin-hood-hashing/3.11.5#6287c40b3396bea819b4751ef6bf8737",
+        "robin-hood-hashing/3.11.5",
         "rapidxml/1.13",
         "rapidjson/cci.20230929",
         "pugixml/1.14",


### PR DESCRIPTION
Windows builds always rebuild `vulkan-validationlayers/1.3.224.1`. This is because of a workaround introduced in PR #60: to avoid a rebuild at that time, `robin-hood-hashing/3.11.5` was fixed to a certain revision. However, using that revision now is avoiding using prebuilt binaries from conancenter. So we can remove that 'workaround' and let the build pick it up from conancenter instead of rebuilding.